### PR TITLE
Pin Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mf2py==1.1.2
+requests==2.26.0
+beautifulsoup4==4.10.0
+lxml==4.7.1


### PR DESCRIPTION
Pinned requirements typically live at the top-level in a `requirements.txt` file. I noticed there was a requirements.txt file inside the docs directory, but it didn't seem like development requirements as it includes this library as a requirement. As such this PR simply adds a minimal requirements.txt file to pin the requirements for the library.

While the main dependencies are likely to be installed in projects using indieweb-utils, it's unclear to me at this time how to best handle  strictly pinned versions version conflicts  between this library and client e.g. Tanzawa etc.. Most of the time it should't make a difference as the APIs don't change, but it might. As such I haven't made any changes to the pyproject.toml / setup.cfg to specify them.