### PR TITLE
add authorship discovery and send webmention tests (per #17)

### DIFF
--- a/tests/test_indieweb_utils.py
+++ b/tests/test_indieweb_utils.py
@@ -54,3 +54,22 @@ class TestWebPageFeedDiscovery:
 
         for f in feeds:
             assert f.url in assumed_feeds
+
+class TestSendWebmention:
+    def test_send_webmention(self):
+        source = "https://jamesg.blog/2021/12/06/advent-of-bloggers-6/"
+        target = "https://jamesg.blog/mugs/"
+
+        message = send_webmention(source, target)
+
+        assert message["status"] == "success"
+
+class TestAuthorshipDiscovery:
+    def test_authorship_discovery(self):
+        url = "https://jamesg.blog/2021/12/06/advent-of-bloggers-6/"
+
+        author = discover_author(url)
+
+        assert author["properties"]["url"] == ["https://jamesg.blog"]
+        assert author["properties"]["name"] == ["James"]
+        assert author["properties"]["photo"] == ["https://jamesg.blog/assets/coffeeshop.jpg"]


### PR DESCRIPTION
I have written a test for the send webmention function and the authorship discovery function.

For additional reference, I get a notification from my webmention endpoint when the test_send_webmention() function runs which indicates the test case is indeed working.

With that said, it might be worth setting up a dummy domain at some point with test cases to which we can all contribute. I would prefer not to get notifications every time the test cases are run :)