### PR TITLE
Add CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements_dev.txt
+    - name: Running tox
+      run: |
+        tox


### PR DESCRIPTION
This PR adds a GitWork Actions Workflow to run tox with each branch / merge that we push. This will help us make sure that all branches don't break tests and we can maintain high quality.

Note this is branches from refactor_tests as it fixes some of the lint / typecheck errors (though not all). Refactor tests ( #20 ) should be merged before this branch.