### PR TITLE
Implement h-feed discovery algorithm

### DIFF
--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -86,7 +86,6 @@ def discover_h_feed(url: str) -> dict:
 
     all_page_feeds = discover_web_page_feeds(url)
 
-    # check for h-feed
     if all_page_feeds.get("text/mf2+html"):
         # url has already been canonicalized by discover_web_page_feeds
         # thus, no canonicalization is needed in this function

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 from urllib import parse as url_parse
 
 import mf2py

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -104,6 +104,3 @@ def discover_h_feed(url: str) -> dict:
         return h_feed[0]
 
     return {}
-
-
-

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -103,6 +103,3 @@ def discover_h_feed(url: str) -> dict:
 
     if h_feed:
         return h_feed[0]
-
-    
-

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional
+from typing import List, Optional, Dict
 from urllib import parse as url_parse
 
 import mf2py
@@ -70,7 +70,7 @@ def discover_web_page_feeds(url: str, user_mime_types: Optional[List[str]] = Non
     return feeds
 
 
-def discover_h_feed(url: str) -> dict:
+def discover_h_feed(url: str) -> Dict:
     """
     Find the main h-feed that represents a web page as per the h-feed Discovery algorithm.
 
@@ -93,12 +93,12 @@ def discover_h_feed(url: str) -> dict:
 
         parsed_feed = mf2py.parse(url=feed)
 
-        h_feed = [item for item in parsed_feed["items"] if item.get("type", [])[0] == "h-feed"]
+        h_feed = [item for item in parsed_feed["items"] if item.get("type") and item.get("type")[0] == "h-feed"]
 
         if h_feed:
             return h_feed[0]
 
-    h_feed = [item for item in parsed_main_page_mf2["items"] if item.get("type", [])[0] == "h-feed"]
+    h_feed = [item for item in parsed_main_page_mf2["items"] if item.get("type") and item.get("type")[0] == "h-feed"]
 
     if h_feed:
         return h_feed[0]

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -86,11 +86,10 @@ def discover_h_feed(url: str) -> dict:
 
     all_page_feeds = discover_web_page_feeds(url)
 
-    if all_page_feeds.get("text/mf2+html"):
-        # url has already been canonicalized by discover_web_page_feeds
-        # thus, no canonicalization is needed in this function
+    get_mf2_feed = [feed for feed in all_page_feeds if feed.mime_type == "text/mf2+html"]
 
-        feed = all_page_feeds.get("text/mf2+html").url
+    if len(get_mf2_feed) > 0:
+        feed = get_mf2_feed[0].url
 
         parsed_feed = mf2py.parse(url=feed)
 
@@ -103,3 +102,8 @@ def discover_h_feed(url: str) -> dict:
 
     if h_feed:
         return h_feed[0]
+
+    return {}
+
+
+


### PR DESCRIPTION
The microformats h-feed specification describes an algorithm to follow when finding the h-feed that represents a page.

This PR implements all of that algorithm, excluding the "implied h-feed" phase for which more clarification is needed before continuing.