### PR TITLE
Fix invalid import paths breaking autodocs

### DIFF
--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -145,10 +145,10 @@ link back to the source.
 
 To check whether there is a two-way rel=me link between two resources, you can use this function:
 
-.. autofunction:: indieweb_utils.get_valid_rel_me_links
+.. autofunction:: indieweb_utils.get_valid_relmeauth_links
 
 This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
 rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
 if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user,
-even if the get_valid_rel_me_links() function found a valid two-way rel=me link.
+even if the get_valid_relmeauth_links() function found a valid two-way rel=me link.
 

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -9,6 +9,7 @@ from .indieauth import (
     is_authenticated,
     redeem_code,
     validate_access_token,
+    validate_authorization_response,
 )
 from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handler
 from .posts.discovery import discover_author, discover_original_post, get_post_type
@@ -47,4 +48,5 @@ __all__ = [
     "_validate_indieauth_response",
     "redeem_code",
     "get_valid_relmeauth_links",
+    "validate_authorization_response",
 ]

--- a/src/indieweb_utils/indieauth/__init__.py
+++ b/src/indieweb_utils/indieauth/__init__.py
@@ -6,7 +6,7 @@ from .flask import (
 from .happ import get_h_app_item
 from .profile import get_profile
 from .relmeauth import get_valid_relmeauth_links
-from .server import redeem_code, validate_access_token
+from .server import redeem_code, validate_access_token, validate_authorization_response
 
 __all__ = [
     "is_authenticated",
@@ -17,4 +17,5 @@ __all__ = [
     "validate_access_token",
     "_validate_indieauth_response",
     "get_valid_relmeauth_links",
+    "validate_authorization_response",
 ]


### PR DESCRIPTION
Sphinx was unable to import two functions which broke autodocs. One was
because the name of the function was different. The other was because
the path in sphinx assumed the function was accessible at the top level
i.e. indieweb.foo, when it wasn't.