### PR TITLE
Improve webmention error classes, fix RelMeAuth test, redesign h-app function 

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 tox==3.24.5
-black==21.12b0
+black==22.6.0
 isort==5.10.1
 pytest==6.2.5
 pytest-pythonpath==0.7.3

--- a/src/indieweb_utils/indieauth/happ.py
+++ b/src/indieweb_utils/indieauth/happ.py
@@ -11,11 +11,11 @@ class ApplicationInfo:
     summary: str
 
 
-class NoHAppFound(Exception):
+class HAppNotFound(Exception):
     pass
 
 
-def get_h_app_item(web_page: str, client_id: str) -> ApplicationInfo:
+def get_h_app_item(web_page: str) -> ApplicationInfo:
     """
     Get the h-app item from the web page.
 
@@ -45,7 +45,7 @@ def get_h_app_item(web_page: str, client_id: str) -> ApplicationInfo:
     parsed_document = mf2py.parse(web_page)
 
     if not parsed_document:
-        raise NoHAppFound("No h-app mf2 data was found on the specified page.")
+        raise HAppNotFound("No h-app mf2 data was found on the specified page.")
 
     for item in parsed_document["items"]:
         if item.get("type") and item.get("type")[0] == "h-app":
@@ -64,4 +64,4 @@ def get_h_app_item(web_page: str, client_id: str) -> ApplicationInfo:
 
             return ApplicationInfo(**value_dict)
 
-    raise NoHAppFound("No h-app mf2 data was found on the specified page.")
+    raise HAppNotFound("No h-app mf2 data was found on the specified page.")

--- a/src/indieweb_utils/indieauth/happ.py
+++ b/src/indieweb_utils/indieauth/happ.py
@@ -56,7 +56,6 @@ def get_h_app_item(web_page: str) -> ApplicationInfo:
             for v in values:
                 value_dict[v] = item["properties"].get(v)
 
-            for v in values:
                 if value_dict[v] is None:
                     value_dict[v] = ""
                 else:

--- a/src/indieweb_utils/posts/discovery.py
+++ b/src/indieweb_utils/posts/discovery.py
@@ -194,7 +194,7 @@ def discover_author(url: str, page_contents: str = "") -> dict:
 
         parsed_mf2 = mf2py.parse(url=url)
 
-        post_author = indieweb_utils.get_post_type(
+        post_author = indieweb_utils.discover_author(
             h_entry
         )
 

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -7,7 +7,13 @@ import requests
 from bs4 import BeautifulSoup
 
 from ..utils.urls import _is_http_url, canonicalize_url
-from ..webmentions.discovery import discover_webmention_endpoint
+from ..webmentions.discovery import (
+    LocalhostEndpointFound,
+    TargetNotProvided,
+    UnacceptableIPAddress,
+    WebmentionEndpointNotFound,
+    discover_webmention_endpoint,
+)
 
 
 @dataclass
@@ -378,7 +384,7 @@ def get_reply_context(url: str, twitter_bearer_token: str = "", summary_word_lim
         webmention_endpoint_url_response = discover_webmention_endpoint(url)
 
         webmention_endpoint_url = webmention_endpoint_url_response.endpoint
-    except Exception:
+    except (TargetNotProvided, WebmentionEndpointNotFound, UnacceptableIPAddress, LocalhostEndpointFound):
         webmention_endpoint_url = ""
 
     parsed = mf2py.parse(doc=page_content.text)

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -31,13 +31,11 @@ class ReplyContext:
 
 
 class ReplyContextRetrievalError(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 class UnsupportedScheme(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 def _get_author_properties(author_url: str, h_entry: dict) -> Tuple[str, str, str]:

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -374,9 +374,12 @@ def get_reply_context(url: str, twitter_bearer_token: str = "", summary_word_lim
     if page_content.status_code != 200:
         raise ReplyContextRetrievalError(f"Page returned a {page_content.status_code} response.")
 
-    webmention_endpoint_url_response = discover_webmention_endpoint(url)
+    try:
+        webmention_endpoint_url_response = discover_webmention_endpoint(url)
 
-    webmention_endpoint_url = webmention_endpoint_url_response.endpoint
+        webmention_endpoint_url = webmention_endpoint_url_response.endpoint
+    except Exception:
+        webmention_endpoint_url = ""
 
     parsed = mf2py.parse(doc=page_content.text)
 

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -30,7 +30,6 @@ class UnacceptableIPAddress(Exception):
 
     Local, loopback, private, reserved, and multicast IP addresses are not acceptable.
     """
-    pass
 
 
 class LocalhostEndpointFound(Exception):

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -16,15 +16,20 @@ class WebmentionDiscoveryResponse:
     endpoint: str
 
 
-class NoTargetProvided(Exception):
+class TargetNotProvided(Exception):
     pass
 
 
-class NoWebmentionEndpointFound(Exception):
+class WebmentionEndpointNotFound(Exception):
     pass
 
 
 class UnacceptableIPAddress(Exception):
+    """
+    Raised if an IP address for a webmention endpoint does not resolve on the public internet.
+
+    Local, loopback, private, reserved, and multicast IP addresses are not acceptable.
+    """
     pass
 
 
@@ -54,14 +59,14 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
         print(webmention_endpoint) # https://webmention.jamesg.blog/webmention
     """
     if not target:
-        raise NoTargetProvided("No target provided.")
+        raise TargetNotProvided("No target provided.")
 
     endpoints = _discover_endpoints(target, [_WEBMENTION])
 
     endpoint = endpoints.get("webmention", None)
 
     if endpoint is None:
-        raise NoWebmentionEndpointFound("No webmention endpoint could be found for this resource.")
+        raise WebmentionEndpointNotFound("No webmention endpoint could be found for this resource.")
 
     # verify if IP address is not allowed
     try:

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -14,8 +14,22 @@ _WEBMENTION = "webmention"  # TODO: Move this to a constants file
 @dataclass
 class WebmentionDiscoveryResponse:
     endpoint: str
-    message: str
-    success: bool
+
+
+class NoTargetProvided(Exception):
+    pass
+
+
+class NoWebmentionEndpointFound(Exception):
+    pass
+
+
+class UnacceptableIPAddress(Exception):
+    pass
+
+
+class LocalhostEndpointFound(Exception):
+    pass
 
 
 def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
@@ -40,15 +54,14 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
         print(webmention_endpoint) # https://webmention.jamesg.blog/webmention
     """
     if not target:
-        return WebmentionDiscoveryResponse(endpoint="", message="Error: A target was not provided.", success=False)
+        raise NoTargetProvided("No target provided.")
 
     endpoints = _discover_endpoints(target, [_WEBMENTION])
 
     endpoint = endpoints.get("webmention", None)
 
     if endpoint is None:
-        message = "No webmention endpoint could be found for this resource."
-        return WebmentionDiscoveryResponse(endpoint="", message=message, success=False)
+        raise NoWebmentionEndpointFound("No webmention endpoint could be found for this resource.")
 
     # verify if IP address is not allowed
     try:
@@ -62,14 +75,12 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
             or endpoint_as_ip.is_reserved is True
             or endpoint_as_ip.is_link_local is True
         ):
-            message = "The endpoint does not connect to an accepted IP address."
-            return WebmentionDiscoveryResponse(endpoint="", message=message, success=False)
+            raise UnacceptableIPAddress("The endpoint does not connect to an accepted IP address.")
     except ValueError:
         pass
 
     if endpoint == "localhost":
-        message = "This resource is not supported."
-        return WebmentionDiscoveryResponse(endpoint="", message=message, success=False)
+        raise LocalhostEndpointFound("The endpoint is localhost.")
 
     if endpoint == "":
         endpoint = target
@@ -82,7 +93,7 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
     if endpoint.startswith("/"):
         endpoint = "https://" + url_parse.urlsplit(target).scheme + endpoint
 
-    return WebmentionDiscoveryResponse(endpoint=endpoint, message="Webmention endpoint found.", success=True)
+    return WebmentionDiscoveryResponse(endpoint=endpoint)
 
 
 def _discover_endpoints(url: str, headers_to_find: List[str]):

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -26,6 +26,7 @@ class UnsupportedProtocolError(Exception):
     """
     Raised if a provided webmention source or target uses a protocol other than http:// or https://.
     """
+
     pass
 
 

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -95,7 +95,7 @@ def send_webmention(source: str, target: str, me: str = "") -> SendWebmentionRes
     response = discovery.discover_webmention_endpoint(target)
 
     if response.endpoint == "":
-        raise GenericWebmentionError(response.message)
+        raise GenericWebmentionError("No webmention endpoint was found.")
 
     # make post request to endpoint with source and target as values
     try:

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -23,6 +23,9 @@ class MissingTargetError(Exception):
 
 
 class UnsupportedProtocolError(Exception):
+    """
+    Raised if a provided webmention source or target uses a protocol other than http:// or https://.
+    """
     pass
 
 
@@ -51,10 +54,10 @@ def _validate_webmention(source: str, target: str):
     """
     Check if a webmention has a provided source, target, and valid protocol.
     """
-    if not source or source == "":
+    if not source:
         raise MissingSourceError("A source was not provided.")
 
-    if not target or target == "":
+    if not target:
         raise MissingTargetError("A target was not provided.")
 
     if not _is_http_url(source) or not _is_http_url(target):

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -43,7 +43,6 @@ class SendWebmentionResponse:
     title: str
     description: str
     url: str
-    success: bool
     status_code: Optional[int]
     headers: List[Header]
 
@@ -107,5 +106,5 @@ def send_webmention(source: str, target: str, me: str = "") -> SendWebmentionRes
         raise GenericWebmentionError(message)
 
     return SendWebmentionResponse(
-        title=message, description=message, url=target, success=True, status_code=r.status_code, headers=headers
+        title=message, description=message, url=target, status_code=r.status_code, headers=headers
     )

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -47,6 +47,20 @@ class SendWebmentionResponse:
     headers: List[Header]
 
 
+def _validate_webmention(source: str, target: str):
+    """
+    Check if a webmention has a provided source, target, and valid protocol.
+    """
+    if not source or source == "":
+        raise MissingSourceError("A source was not provided.")
+
+    if not target or target == "":
+        raise MissingTargetError("A target was not provided.")
+
+    if not _is_http_url(source) or not _is_http_url(target):
+        raise UnsupportedProtocolError("Only HTTP/HTTPS URLs are supported.")
+
+
 def send_webmention(source: str, target: str, me: str = "") -> SendWebmentionResponse:
     """
     Send a webmention to a target URL.
@@ -60,23 +74,17 @@ def send_webmention(source: str, target: str, me: str = "") -> SendWebmentionRes
     :return: The response from the webmention endpoint.
     :rtype: SendWebmentionResponse
     """
-    if not source:
-        raise MissingSourceError("A source was not provided.")
 
-    if not target:
-        raise MissingTargetError("A target was not provided.")
-
-    if not _is_http_url(source) or not _is_http_url(target):
-        raise UnsupportedProtocolError("Only HTTP/HTTPS URLs are supported.")
+    _validate_webmention(source, target)
 
     # if domain is not approved, don't allow access
     if me != "":
         target_domain = url_parse.urlsplit(target).scheme
 
+        raw_domain = me
+
         if "/" in me.strip("/"):
             raw_domain = url_parse.urlsplit(me).scheme
-        else:
-            raw_domain = me
 
         if not target_domain.endswith(raw_domain):
             raise TargetIsNotApprovedDomain("Target must be a {me} post.")

--- a/tests/test_indieauth/test_happ.py
+++ b/tests/test_indieauth/test_happ.py
@@ -8,7 +8,7 @@ def test_handles_missing_name():
     """Test name is set to the me url if no name found."""
     web_page = """
     <div class='h-app'>
-        <h1 class="p-name">Application Name</h1>
+        <h1><a href="https://example.com" class="u-url p-name">Application Name</a></h1>
         <p class="p-summary">Application Summary</p>
         <img src="https://example.com/me.jpg" class="u-photo u-logo"/>
     </div>

--- a/tests/test_indieauth/test_happ.py
+++ b/tests/test_indieauth/test_happ.py
@@ -14,9 +14,7 @@ def test_handles_missing_name():
     </div>
     """
 
-    client_id = "https://example.com"
-
-    response = happ.get_h_app_item(web_page, client_id)
+    response = happ.get_h_app_item(web_page)
     assert response.name == "Application Name"
     assert response.url == "https://example.com"
     assert response.logo == "https://example.com/me.jpg"

--- a/tests/test_indieauth/test_relmeauth.py
+++ b/tests/test_indieauth/test_relmeauth.py
@@ -15,4 +15,4 @@ class TestRelMeAuthLinkDiscovery:
 
         responses.add(responses.Response(method="GET", url=url, body=index))
 
-        assert target(url) == ["https://indieweb.social/@capjamesg"]
+        assert target(url) == ["https://sr.ht/~capjamesg/"]


### PR DESCRIPTION
This PR adds new webmention error classes, removing dependence on an opaque "success" boolean to indicate whether a webmention was sent successfully. This PR also resolves issues with the RelMeAuth test. Also, I have rewritten the h-app logic to depend on mf2py, which has robust and well-tested mf2 parsing. This replaces our implementation which is not as flexible and was not tested against the mf2 parsing specification.