### PR TITLE
Add exception documentation to codebase

### DIFF
--- a/src/indieweb_utils/indieauth/flask.py
+++ b/src/indieweb_utils/indieauth/flask.py
@@ -67,6 +67,8 @@ def indieauth_callback_handler(
     :return: A message indicating the result of the callback (success or failure) and the token endpoint response.
         The endpoint response will be equal to None if the callback failed.
     :rtype: tuple[str, dict]
+
+    :raises AuthenticationError: Authentication process could not be completed due to an error.
     """
 
     if state != session_state:
@@ -110,6 +112,8 @@ def is_authenticated(token_endpoint: str, headers: dict, session: dict, approved
     :param approved_user: The optional URL of the that is approved to use the API.
     :return: True if the user is authenticated, False otherwise.
     :rtype: bool
+
+    :raises AuthenticationError: Authentication process could not be completed due to an error.
     """
     if headers.get("Authorization") is not None:
         access_token = headers["Authorization"].split(" ")[-1]

--- a/src/indieweb_utils/indieauth/happ.py
+++ b/src/indieweb_utils/indieauth/happ.py
@@ -40,6 +40,8 @@ def get_h_app_item(web_page: str) -> ApplicationInfo:
         )
 
         print(h_app_item.name) # Quill
+
+    :raises HAppNotFound: Raised if no mf2 h-app data was found on the specified page.
     """
 
     parsed_document = mf2py.parse(web_page)

--- a/src/indieweb_utils/indieauth/profile.py
+++ b/src/indieweb_utils/indieauth/profile.py
@@ -43,16 +43,14 @@ def get_profile(me: str) -> Profile:
 
         me = "https://jamesg.blog"
 
-        try:
-            profile = indieweb_utils.get_profile(me)
-        except indieweb_utils.ProfileError as exception:
-            # returned when a profile cannot be retrieved
-            raise exception
+        profile = indieweb_utils.get_profile(me)
 
         assert profile.email == "james@jamesg.blog"
         assert profile.name == "James"
         assert profile.photo == "https://jamesg.blog/me.jpg"
         assert profile.url == "https://jamesg.blog
+
+    :raises ProfileError: Profile could not be retrieved.
     """
 
     try:

--- a/src/indieweb_utils/indieauth/profile.py
+++ b/src/indieweb_utils/indieauth/profile.py
@@ -43,7 +43,11 @@ def get_profile(me: str) -> Profile:
 
         me = "https://jamesg.blog"
 
-        profile = indieweb_utils.get_profile(me)
+        try:
+            profile = indieweb_utils.get_profile(me)
+        except indieweb_utils.ProfileError as exception:
+            # returned when a profile cannot be retrieved
+            raise exception
 
         assert profile.email == "james@jamesg.blog"
         assert profile.name == "James"

--- a/src/indieweb_utils/indieauth/server.py
+++ b/src/indieweb_utils/indieauth/server.py
@@ -309,7 +309,7 @@ def redeem_code(
         print(token_response.token_type)
         print(token_response.scope)
         print(token_response.me)
-    
+
     :raises AuthorizationCodeExpiredError: If the authorization code has expired.
     :raises TokenValidationError: If the decoded code is invalid.
     :raises AuthenticationError: If the token request is invalid.

--- a/src/indieweb_utils/indieauth/server.py
+++ b/src/indieweb_utils/indieauth/server.py
@@ -82,20 +82,17 @@ def validate_authorization_response(
 
         import indieweb_utils
 
-        # validate authorization response
-        # if response is invalid, an exception will be raised
-        try:
-            indieweb_utils.validate_authorization_response(
-                grant_type="authorization_code",
-                code="12345",
-                client_id="https://example.com",
-                redirect_uri="https://example.com/callback",
-                code_challenge="12345",
-                code_challenge_method="S256",
-                allowed_methods=["S256"]
-            )
-        except indieweb_utils.TokenValidationError as e:
-            print(e)
+        indieweb_utils.validate_authorization_response(
+            grant_type="authorization_code",
+            code="12345",
+            client_id="https://example.com",
+            redirect_uri="https://example.com/callback",
+            code_challenge="12345",
+            code_challenge_method="S256",
+            allowed_methods=["S256"]
+        )
+
+    :raises TokenValidationError: If the response is invalid.
     """
 
     if grant_type != "authorization_code":
@@ -146,18 +143,16 @@ def _verify_decoded_code(
         decoded_redirect_uri = "https://example.com/callback"
         decoded_expires = 3600
 
-        try:
             code_is_valid = indieweb_utils.indieauth.server._verify_decoded_code(
-                client_id,
-                redirect_uri,
-                decoded_client_id,
-                decoded_redirect_uri,
-                decoded_expires
-            )
-        except indieweb_utils.AuthorizationCodeExpiredError:
-            print(e)
-        except indieweb_utils.TokenValidationError as e:
-            print(e)
+            client_id,
+            redirect_uri,
+            decoded_client_id,
+            decoded_redirect_uri,
+            decoded_expires
+        )
+
+    :raises AuthorizationCodeExpiredError: If the authorization code has expired.
+    :raises TokenValidationError: If the decoded code is invalid.
     """
 
     if int(time.time()) > decoded_expires:
@@ -217,19 +212,18 @@ def generate_auth_token(
         import random
         import string
 
-        try:
-            token = indieweb_utils.indieauth.server.generate_auth_token(
-                me="https://test.example.com/user",
-                client_id="https://example.com",
-                redirect_uri="https://example.com/callback",
-                response_type="code",
-                state="".join(random.choice(string.ascii_letters) for _ in range(32)),
-                code_challenge_method="S256",
-                final_scope="read write",
-                secret_key="secret"
-            )
-        except indieweb_utils.AuthenticationError as e:
-            print(e)
+        token = indieweb_utils.indieauth.server.generate_auth_token(
+            me="https://test.example.com/user",
+            client_id="https://example.com",
+            redirect_uri="https://example.com/callback",
+            response_type="code",
+            state="".join(random.choice(string.ascii_letters) for _ in range(32)),
+            code_challenge_method="S256",
+            final_scope="read write",
+            secret_key="secret"
+        )
+
+    :raises AuthenticationError: Authentication request is invalid.
     """
 
     if not all([client_id, redirect_uri, response_type, state]):
@@ -302,26 +296,23 @@ def redeem_code(
 
         import indieweb_utils
 
-        try:
-            token_response = indieweb_utils.indieauth.server.redeem_code(
-                grant_type="authorization_code",
-                code="code",
-                client_id="https://example.com",
-                redirect_uri="https://example.com/callback",
-                code_verifier="code_verifier",
-                secret_key="secret"
-            )
+        token_response = indieweb_utils.indieauth.server.redeem_code(
+            grant_type="authorization_code",
+            code="code",
+            client_id="https://example.com",
+            redirect_uri="https://example.com/callback",
+            code_verifier="code_verifier",
+            secret_key="secret"
+        )
 
-            print(token_response.access_token)
-            print(token_response.token_type)
-            print(token_response.scope)
-            print(token_response.me)
-        except indieweb_utils.AuthorizationCodeExpiredError:
-            print(e)
-        except indieweb_utils.TokenValidationError as e:
-            print(e)
-        except indieweb_utils.AuthenticationError as e:
-            print(e)
+        print(token_response.access_token)
+        print(token_response.token_type)
+        print(token_response.scope)
+        print(token_response.me)
+    
+    :raises AuthorizationCodeExpiredError: If the authorization code has expired.
+    :raises TokenValidationError: If the decoded code is invalid.
+    :raises AuthenticationError: If the token request is invalid.
     """
 
     if not code or not client_id or not redirect_uri or not grant_type:
@@ -407,6 +398,9 @@ def validate_access_token(
             print(e)
         except indieweb_utils.AuthorizationCodeExpiredError as e:
             print(e)
+
+    :raises AuthorizationCodeExpiredError: Authorization code has expired.
+    :raises AuthenticationError: Authorization code provided is invalid.
     """
 
     try:

--- a/src/indieweb_utils/posts/discovery.py
+++ b/src/indieweb_utils/posts/discovery.py
@@ -18,6 +18,7 @@ PERMASHORTLINK_CITATION_BRACKET_MATCHING = r"\((.*?)\)"
 class PostDiscoveryError(Exception):
     pass
 
+
 class PostTypeFormattingError(Exception):
     pass
 

--- a/src/indieweb_utils/posts/discovery.py
+++ b/src/indieweb_utils/posts/discovery.py
@@ -102,14 +102,11 @@ def discover_original_post(posse_permalink: str) -> str:
 
         import indieweb_utils
 
-        try:
-            original_post_url = indieweb_utils.discover_original_post("https://example.com")
-        except indieweb_utils.PostDiscoveryError as exception:
-            # raised when a candidate URL cannot be retrieved
-            # or when a specified post is not marked up with h-entry
-            raise exception
+        original_post_url = indieweb_utils.discover_original_post("https://example.com")
 
         print(original_post_url)
+
+    :raises PostDiscoveryError: A candidate URL cannot be retrieved or when a specified post is not marked up with h-entry.
     """
     parsed_post = BeautifulSoup(posse_permalink, "lxml")
 
@@ -300,15 +297,13 @@ def get_post_type(h_entry: dict, custom_properties: List[Tuple[str, str]] = []) 
 
         h_entry = [e for e in parsed_mf2["items"] if e["type"] == ["h-entry"]][0]
 
-        try:
-            post_type = indieweb_utils.get_post_type(
-                h_entry
-            )
-        except indieweb_utils.PostTypeFormattingError as exception:
-            # raised when you specify a custom_properties tuple in the wrong format
-            raise exception
+        post_type = indieweb_utils.get_post_type(
+            h_entry
+        )
 
         print(post_type) # article
+
+    :raises PostTypeFormattingError: Raised when you specify a custom_properties tuple in the wrong format.
     """
     post = h_entry.get("properties")
 

--- a/src/indieweb_utils/posts/representative_h_card.py
+++ b/src/indieweb_utils/posts/representative_h_card.py
@@ -24,6 +24,8 @@ def get_representative_h_card(url: str) -> Dict[str, Any]:
     :type url: str
     :return: The representative h-card.
     :rtype: dict
+
+    :raises RepresentativeHCardParsingError: Representative h-card could not be parsed.
     """
     mf2_data = mf2py.parse(url=url)
 

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -357,20 +357,16 @@ def get_reply_context(url: str, twitter_bearer_token: str = "", summary_word_lim
 
         import indieweb_utils
 
-        try:
-            context = indieweb_utils.get_reply_context(
-                url="https://jamesg.blog",
-                summary_word_limit=50
-            )
-        except indiweb_utils.ReplyContextRetrievalError as exception:
-            # raised when reply context cannot be retrieved
-            raise ReplyContextRetrievalError
-        except indieweb_utils.UnsupportedScheme as exception:
-            # raised when specified URL does not use http:// or https://
-            raise exception
+        context = indieweb_utils.get_reply_context(
+            url="https://jamesg.blog",
+            summary_word_limit=50
+        )
 
         # print the name of the specified page to the console
         print(context.name) # "Home | James' Coffee Blog"
+
+    :raises ReplyContextRetrievalError: Reply context cannot be retrieved.
+    :raises UnsupportedScheme: The specified URL does not use http:// or https://.
     """
 
     parsed_url = url_parse.urlsplit(url)

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -194,7 +194,7 @@ def _generate_tweet_reply_context(url: str, twitter_bearer_token: str, webmentio
         raise ReplyContextRetrievalError("Could not retrieve tweet context from the Twitter API.")
 
     if r and r.status_code != 200:
-        raise Exception(f"Twitter API returned {r.status_code}")
+        raise ReplyContextRetrievalError(f"Twitter API returned {r.status_code}")
 
     base_url = f"https://api.twitter.com/2/users/{r.json()['data'].get('author_id')}"
 
@@ -357,10 +357,17 @@ def get_reply_context(url: str, twitter_bearer_token: str = "", summary_word_lim
 
         import indieweb_utils
 
-        context = indieweb_utils.get_reply_context(
-            url="https://jamesg.blog",
-            summary_word_limit=50
-        )
+        try:
+            context = indieweb_utils.get_reply_context(
+                url="https://jamesg.blog",
+                summary_word_limit=50
+            )
+        except indiweb_utils.ReplyContextRetrievalError as exception:
+            # raised when reply context cannot be retrieved
+            raise ReplyContextRetrievalError
+        except indieweb_utils.UnsupportedScheme as exception:
+            # raised when specified URL does not use http:// or https://
+            raise exception
 
         # print the name of the specified page to the console
         print(context.name) # "Home | James' Coffee Blog"

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -15,6 +15,7 @@ _WEBMENTION = "webmention"  # TODO: Move this to a constants file
 class WebmentionDiscoveryResponse:
     endpoint: str
 
+
 class TargetNotProvided(Exception):
     pass
 

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -51,24 +51,16 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
 
         target = "https://jamesg.blog/"
 
-        try:
-            webmention_endpoint = indieweb_utils.discover_webmention_endpoint(
-                target
-            )
-        except indieweb_utils.TargetNotProvided as exception:
-            # target was None
-            raise exception
-        except indieweb_utils.WebmentionEndpointNotFound as exception:
-            # no webmention endpoint was found on the target URL
-            raise exception
-        except indieweb_utils.UnacceptableIPAddress as exception:
-            # endpoint does not connect to an accepted IP
-            raise exception
-        except indieweb_utils.LocalhostEndpointFound as exception:
-            # discovered endpoint is equal to localhost
-            raise exception
+        webmention_endpoint = indieweb_utils.discover_webmention_endpoint(
+            target
+        )
 
         print(webmention_endpoint) # https://webmention.jamesg.blog/webmention
+
+    :raises TargetNotProvided: Target is not provided.
+    :raises WebmentionEndpointNotFound: Webmention endpoint is not found.
+    :raises UnacceptableIPAddress: Endpoint does not connect to an accepted IP.
+    :raises LocalhostEndpointFound: Discovered endpoint is equal to localhost.
     """
     if not target:
         raise TargetNotProvided("No target provided.")
@@ -136,15 +128,13 @@ def discover_endpoints(url: str, headers_to_find: List[str]):
         # find the webmention header on a web page
         headers_to_find = ["webmention"]
 
-        try:
-            endpoints = indieweb_utils.discover_endpoints(
-                url
-            )
-        except requests.exceptions.RequestException as exception:
-            # error making the network request to discover endpoints
-            raise exception
+        endpoints = indieweb_utils.discover_endpoints(
+            url
+        )
 
         print(webmention_endpoint) # {'webmention': 'https://webmention.jamesg.blog/webmention'}
+
+    :raises requests.exceptions.RequestException: Error raised while making the network request to discover endpoints.
     """
     response: Dict[str, str] = {}
 

--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -77,6 +77,10 @@ def send_webmention(source: str, target: str, me: str = "") -> SendWebmentionRes
     :type me: str
     :return: The response from the webmention endpoint.
     :rtype: SendWebmentionResponse
+
+    :raises TargetIsNotApprovedDomain: Target is not in list of approved domains.
+    :raises GenericWebmentionError: Generic webmention error.
+    :raises CouldNotConnectToWebmentionEndpoint: Could not connect to the receiver's webmention endpoint.
     """
 
     _validate_webmention(source, target)

--- a/src/indieweb_utils/webmentions/validate.py
+++ b/src/indieweb_utils/webmentions/validate.py
@@ -152,7 +152,7 @@ def validate_webmention(
         webmention_is_valid = indieweb_utils.validate_webmention(
             source, target
         )
-        
+
         print(webmention_is_valid) # Should return True
 
     :raises WebmentionValidationError: Webmention is invalid.

--- a/src/indieweb_utils/webmentions/validate.py
+++ b/src/indieweb_utils/webmentions/validate.py
@@ -149,9 +149,16 @@ def validate_webmention(
         source = "https://jamesg.blog/"
         target = "https://jamesg.blog/mugs/"
 
-        webmention_is_valid = indieweb_utils.validate_webmention(
-            source, target
-        )
+        try:
+            webmention_is_valid = indieweb_utils.validate_webmention(
+                source, target
+            )
+        except indieweb_utils.WebmentionValidationError as exception:
+            # returns information about why webmention validation failed
+            raise exception
+        except indeweb_utils.WebmentionIsGone:
+            # returns when the source of a webmention reports a 410 status code
+            raise Exception("Webmention returned a 410 response.") 
 
         print(webmention_is_valid) # Should return True
     """

--- a/src/indieweb_utils/webmentions/validate.py
+++ b/src/indieweb_utils/webmentions/validate.py
@@ -158,7 +158,7 @@ def validate_webmention(
             raise exception
         except indeweb_utils.WebmentionIsGone:
             # returns when the source of a webmention reports a 410 status code
-            raise Exception("Webmention returned a 410 response.") 
+            raise Exception("Webmention returned a 410 response.")
 
         print(webmention_is_valid) # Should return True
     """

--- a/src/indieweb_utils/webmentions/validate.py
+++ b/src/indieweb_utils/webmentions/validate.py
@@ -149,18 +149,14 @@ def validate_webmention(
         source = "https://jamesg.blog/"
         target = "https://jamesg.blog/mugs/"
 
-        try:
-            webmention_is_valid = indieweb_utils.validate_webmention(
-                source, target
-            )
-        except indieweb_utils.WebmentionValidationError as exception:
-            # returns information about why webmention validation failed
-            raise exception
-        except indeweb_utils.WebmentionIsGone:
-            # returns when the source of a webmention reports a 410 status code
-            raise Exception("Webmention returned a 410 response.")
-
+        webmention_is_valid = indieweb_utils.validate_webmention(
+            source, target
+        )
+        
         print(webmention_is_valid) # Should return True
+
+    :raises WebmentionValidationError: Webmention is invalid.
+    :raises WebmentionIsGone: Webmention source returns a 410 Gone code.
     """
 
     if source.strip("/") == target.strip("/"):


### PR DESCRIPTION
This PR adds `except` handlers to the examples in docstrings where a function may raise an exception. This change has been made to make examples more comprehensive and to provide clear guidance on proper exception handling when using IndieWeb utils.