### PR TITLE
Make changes to and add tests for `discover_h_feed`

### DIFF
--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -1,6 +1,6 @@
 # Imports added for API backwards compatibility
 
-from .feeds import FeedUrl, discover_web_page_feeds
+from .feeds import FeedUrl, discover_web_page_feeds, discover_h_feed
 from .indieauth import (
     _validate_indieauth_response,
     get_h_app_item,
@@ -49,4 +49,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "discover_h_feed"
 ]

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -1,6 +1,6 @@
 # Imports added for API backwards compatibility
 
-from .feeds import FeedUrl, discover_web_page_feeds, discover_h_feed
+from .feeds import FeedUrl, discover_h_feed, discover_web_page_feeds
 from .indieauth import (
     _validate_indieauth_response,
     get_h_app_item,
@@ -49,5 +49,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
-    "discover_h_feed"
+    "discover_h_feed",
 ]

--- a/src/indieweb_utils/feeds/__init__.py
+++ b/src/indieweb_utils/feeds/__init__.py
@@ -1,3 +1,3 @@
-from .discovery import FeedUrl, discover_web_page_feeds, discover_h_feed
+from .discovery import FeedUrl, discover_h_feed, discover_web_page_feeds
 
 __all__ = ["discover_web_page_feeds", "FeedUrl", "discover_h_feed"]

--- a/src/indieweb_utils/feeds/__init__.py
+++ b/src/indieweb_utils/feeds/__init__.py
@@ -1,3 +1,3 @@
-from .discovery import FeedUrl, discover_web_page_feeds
+from .discovery import FeedUrl, discover_web_page_feeds, discover_h_feed
 
-__all__ = ["discover_web_page_feeds", "FeedUrl"]
+__all__ = ["discover_web_page_feeds", "FeedUrl", "discover_h_feed"]

--- a/src/indieweb_utils/feeds/discovery.py
+++ b/src/indieweb_utils/feeds/discovery.py
@@ -99,7 +99,7 @@ def discover_web_page_feeds(url: str, user_mime_types: Optional[List[str]] = Non
     return feeds
 
 
-def discover_h_feed(url: str) -> Dict:
+def discover_h_feed(url: str, html: str = "") -> Dict:
     """
     Find the main h-feed that represents a web page as per the h-feed Discovery algorithm.
 
@@ -107,11 +107,16 @@ def discover_h_feed(url: str) -> Dict:
 
     :param url: The URL of the page whose associated feeds you want to retrieve.
     :type url: str
+    :param html: The HTML of a page whose feeds you want to retrieve
+    :type html: str
     :return: The h-feed data.
     :rtype: dict
     """
 
-    parsed_main_page_mf2 = mf2py.parse(url=url)
+    if html:
+        parsed_main_page_mf2 = mf2py.parse(doc=html)
+    else:
+        parsed_main_page_mf2 = mf2py.parse(url=url)
 
     all_page_feeds = discover_web_page_feeds(url)
 

--- a/tests/test_feeds/test_discovery.py
+++ b/tests/test_feeds/test_discovery.py
@@ -24,3 +24,11 @@ class TestWebPageFeedDiscovery:
 
         for feed in actual_feeds:
             assert feed.url in expected_feeds
+
+class TestHFeedDiscovery:
+    @pytest.fixture
+    def target(self):
+        from indieweb_utils import discover_h_feed
+
+        return discover_h_feed
+    

--- a/tests/test_feeds/test_discovery.py
+++ b/tests/test_feeds/test_discovery.py
@@ -25,10 +25,18 @@ class TestWebPageFeedDiscovery:
         for feed in actual_feeds:
             assert feed.url in expected_feeds
 
+
 class TestHFeedDiscovery:
     @pytest.fixture
     def target(self):
         from indieweb_utils import discover_h_feed
 
         return discover_h_feed
-    
+
+    @responses.activate
+    def test_h_feed_discovery(self, target, index, index_url):
+        responses.add(responses.Response(method="GET", url=index_url, body=index))
+
+        h_feed = target(index_url)
+
+        assert h_feed["children"][0]["properties"] != {}


### PR DESCRIPTION
This PR:

1. Fixes imports so `discover_h_feed()` can be imported from the top level (i.e. `indieweb_utils.discover_h_feed()`).
2. Adds a `html` option to the `discover_h_feed()` function as part of our IO refactor.
3. Adds a test case for the function to our test suite.