### PR TITLE
Fix IndieAuth documentation imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ project = "IndieWeb Utils"
 copyright = "capjamesg 2022"
 author = "capjamesg"
 
-sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, os.path.abspath("../../src/"))
 
 release = "0.2.0"
 version = "0.2.0"

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -1,6 +1,6 @@
 # Imports added for API backwards compatibility
 
-from .feeds import FeedUrl, discover_web_page_feeds
+from .feeds import FeedUrl, discover_h_feed, discover_web_page_feeds
 from .indieauth import (
     _validate_indieauth_response,
     get_h_app_item,
@@ -10,6 +10,7 @@ from .indieauth import (
     redeem_code,
     validate_access_token,
     validate_authorization_response,
+    generate_auth_token
 )
 from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handler
 from .posts.discovery import discover_author, discover_original_post, get_post_type
@@ -49,4 +50,6 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "discover_h_feed",
+    "generate_auth_token"
 ]

--- a/src/indieweb_utils/feeds/__init__.py
+++ b/src/indieweb_utils/feeds/__init__.py
@@ -1,3 +1,3 @@
-from .discovery import FeedUrl, discover_web_page_feeds
+from .discovery import FeedUrl, discover_web_page_feeds, discover_h_feed
 
-__all__ = ["discover_web_page_feeds", "FeedUrl"]
+__all__ = ["discover_web_page_feeds", "FeedUrl", "discover_h_feed"]

--- a/src/indieweb_utils/indieauth/__init__.py
+++ b/src/indieweb_utils/indieauth/__init__.py
@@ -1,12 +1,12 @@
 from .flask import (
     _validate_indieauth_response,
     indieauth_callback_handler,
-    is_authenticated,
+    is_authenticated
 )
 from .happ import get_h_app_item
 from .profile import get_profile
 from .relmeauth import get_valid_relmeauth_links
-from .server import redeem_code, validate_access_token, validate_authorization_response
+from .server import redeem_code, validate_access_token, validate_authorization_response, generate_auth_token
 
 __all__ = [
     "is_authenticated",
@@ -18,4 +18,5 @@ __all__ = [
     "_validate_indieauth_response",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "generate_auth_token",
 ]

--- a/src/indieweb_utils/indieauth/server.py
+++ b/src/indieweb_utils/indieauth/server.py
@@ -218,7 +218,7 @@ def generate_auth_token(
         import string
 
         try:
-            token = indieweb_utils.indieauth.server.generate_auth_token(
+            token = indieweb_utils.generate_auth_token(
                 me="https://test.example.com/user",
                 client_id="https://example.com",
                 redirect_uri="https://example.com/callback",

--- a/src/indieweb_utils/posts/discovery.py
+++ b/src/indieweb_utils/posts/discovery.py
@@ -177,6 +177,8 @@ def discover_author(url: str, page_contents: str = "") -> dict:
     """
     Discover the author of a post per the IndieWeb Authorship specification.
 
+    refs: https://indieweb.org/authorship-spec
+
     :param url: The URL of the post.
     :type url: str
     :param page_contents: The optional page contents to use.


### PR DESCRIPTION
The IndieAuth documentation was not rendering properly in Sphinx. This PR includes a path change in the Sphinx configuration and a few import changes to ensure all IndieAuth functions can be imported as expected.