### PR TITLE
Make `discover_endpoint` part of the library

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -74,6 +74,7 @@ Here are some example values for use with this function:
     headers_to_find = ["hub", "self"] # discover WebSub endpoints
     headers_to_find = ["micropub"] # discover a Micropub endpoint
     headers_to_find = ["microsub"] # discover a Microsub endpoint
+    headers_to_find = ["syndication", "shortlink"] # useful for interpreting Micropub success responses (ref: https://www.w3.org/TR/micropub/#h-response)
 
 Discover a Webmention Endpoint
 ------------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -56,10 +56,31 @@ By default, this function contains all of the attributes in the Post Type Discov
 
 Custom properties are added to the end of the post type discovery list, just before the "article" property. All specification property types are checked before your custom attribute.
 
+Discover an Endpoint
+-----------------------------
+
+You can discover an endpoint from a HTTP header or a HTML `link` tag using the `discover_endpoint` function.
+
+The `discover_endpoint` function uses this syntax:
+
+.. autofunction:: indieweb_utils.discover_endpoint
+
+Here are some example values for use with this function:
+
+.. codeblock:: python
+
+    headers_to_find = ["indieauth-metadata"] # discover an IndieAuth metadata endpoint
+    headers_to_find = ["authorization_endpoint", "token_endpoint"] # discover IndieAuth authorization and token endpoints
+    headers_to_find = ["hub", "self"] # discover WebSub endpoints
+    headers_to_find = ["micropub"] # discover a Micropub endpoint
+    headers_to_find = ["microsub"] # discover a Microsub endpoint
+
 Discover a Webmention Endpoint
 ------------------------------------
 
 Webmention endpoint discovery is useful if you want to know if you can send webmentions to a site or if you want to send a webmention to a site.
+
+This function both finds a Webmention endpoint and validates it. This function should be used to discover Webmention endpoints instead of `discover_endpoint()`, which is more generic and performs no validation on resources it discovers.
 
 You can discover if a URL has an associated webmention endpoint using the `discover_webmention_endpoint` function:
 

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -18,10 +18,10 @@ from .replies import ReplyContext, get_reply_context
 from .utils.urls import canonicalize_url
 from .webmentions import (
     SendWebmentionResponse,
+    discover_endpoint,
     discover_webmention_endpoint,
     send_webmention,
     validate_webmention,
-    discover_endpoint
 )
 
 __version__ = "0.2.0"
@@ -50,5 +50,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
-    "discover_endpoint"
+    "discover_endpoint",
 ]

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -21,6 +21,7 @@ from .webmentions import (
     discover_webmention_endpoint,
     send_webmention,
     validate_webmention,
+    discover_endpoint
 )
 
 __version__ = "0.2.0"
@@ -49,4 +50,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "discover_endpoint"
 ]

--- a/src/indieweb_utils/webmentions/__init__.py
+++ b/src/indieweb_utils/webmentions/__init__.py
@@ -1,5 +1,5 @@
-from .discovery import discover_webmention_endpoint
+from .discovery import discover_webmention_endpoint, discover_endpoint
 from .send import SendWebmentionResponse, send_webmention
 from .validate import validate_webmention
 
-__all__ = ["send_webmention", "validate_webmention", "discover_webmention_endpoint", "SendWebmentionResponse"]
+__all__ = ["send_webmention", "validate_webmention", "discover_webmention_endpoint", "SendWebmentionResponse", "discover_endpoint"]

--- a/src/indieweb_utils/webmentions/__init__.py
+++ b/src/indieweb_utils/webmentions/__init__.py
@@ -1,5 +1,11 @@
-from .discovery import discover_webmention_endpoint, discover_endpoint
+from .discovery import discover_endpoint, discover_webmention_endpoint
 from .send import SendWebmentionResponse, send_webmention
 from .validate import validate_webmention
 
-__all__ = ["send_webmention", "validate_webmention", "discover_webmention_endpoint", "SendWebmentionResponse", "discover_endpoint"]
+__all__ = [
+    "send_webmention",
+    "validate_webmention",
+    "discover_webmention_endpoint",
+    "SendWebmentionResponse",
+    "discover_endpoint",
+]

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -60,7 +60,7 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
     if not target:
         raise TargetNotProvided("No target provided.")
 
-    endpoints = _discover_endpoints(target, [_WEBMENTION])
+    endpoints = discover_endpoints(target, [_WEBMENTION])
 
     endpoint = endpoints.get("webmention", None)
 
@@ -100,7 +100,7 @@ def discover_webmention_endpoint(target: str) -> WebmentionDiscoveryResponse:
     return WebmentionDiscoveryResponse(endpoint=endpoint)
 
 
-def _discover_endpoints(url: str, headers_to_find: List[str]):
+def discover_endpoints(url: str, headers_to_find: List[str]):
     """
     Return a dictionary of specified endpoint locations for the given URL, if available.
 
@@ -122,7 +122,7 @@ def _discover_endpoints(url: str, headers_to_find: List[str]):
         # find the webmention header on a web page
         headers_to_find = ["webmention"]
 
-        endpoints = indieweb_utils._discover_endpoints(
+        endpoints = indieweb_utils.discover_endpoints(
             url
         )
 


### PR DESCRIPTION
We implemented `_discover_endpoint()` as a private function for use in finding a Webmention endpoint. However, this function has broader use cases. For instance, one could use it to discover WebSub or IndieAuth endpoints.

This PR:

1. Renames `_discover_endpoint()` to `discover_endpoint()`.
2. Adds documentation on use of `discover_endpoint()`.
3. Adds the requisite imports to allow using `indieweb_utils.discover_endpoint()`.