### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ project = "IndieWeb Utils"
 copyright = "capjamesg 2022"
 author = "capjamesg"
 
-sys.path.insert(0, os.path.abspath("../../../src/"))
+sys.path.insert(0, os.path.abspath("../../src/"))
 
 release = "0.2.0"
 version = "0.2.0"

--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -72,7 +72,7 @@ You can later refer to these values during the stage where you decode a token.
 
 Here is the syntax for this function:
 
-.. autofunction:: indieweb_utils.generate_auth_token
+.. autofunction:: indieweb_utils.indieauth.server.generate_auth_token
 
 This function returns both the code you should send to the client in the authentication redirect
 response as well as the code_verifier used in the token. This code_verifier should be saved,


### PR DESCRIPTION
Corrects the path so docs are referencing the src directory in the repository and corrects the path for generate_auth_token's autofunction.