### PR TITLE
Split up docs

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -4,6 +4,7 @@ Contents
 .. toctree::
 
    usage
+   discovery
    indieauth
    webmention
    changelog

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -5,4 +5,5 @@ Contents
 
    usage
    indieauth
+   webmention
    changelog

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -60,6 +60,30 @@ This function returns a single string with the post type of the specified web pa
 See the `Post Type Discovery specification <https://indieweb.org/post-type-discovery>`_ for a full list of post types.
 
 
+Custom Properties
+------------------------
+
+The structure of the custom properties tuple is:
+
+.. code-block:: python
+
+   (attribute_to_look_for, value_to_return)
+
+An example custom property value is:
+
+.. code-block:: python
+
+    custom_properties = [
+        ("poke-of", "poke")
+    ]
+
+This function would look for a poke-of attribute on a web page and return the "poke" value.
+
+By default, this function contains all of the attributes in the Post Type Discovery mechanism.
+
+Custom properties are added to the end of the post type discovery list, just before the "article" property. All specification property types are checked before your custom attribute.
+
+
 Find the original version of a post
 ------------------------------------
 

--- a/docs/source/discovery.rst
+++ b/docs/source/discovery.rst
@@ -1,0 +1,84 @@
+Discovery
+==========
+
+Indieweb utils provides a number of functions to help you determine properties from webpages.
+
+
+Find an article author
+------------------------------------
+
+You can discover the original author of an article as per the Authorship Specification.
+
+To do so, use this function:
+
+.. autofunction:: indieweb_utils.discover_author
+
+Here are the arguments you can use:
+
+- `url`: The URL of the web page whose author you want to discover.
+- `page_contents`: The unmodified HTML of a web page whose author you want to discover.
+
+The page_contents argument is optional.
+
+If no page_contents argument is specified, the URL you stated is retrieved. Then, authorship inference begins.
+
+If you specify a page_contents value, the HTML you parsed is used for authorship discovery. This saves on a HTML request if you have already retrieved the HTML for another reason (for example, if you need to retreive other values in the page HTML). You still need to specify a URL even if you specify a page_contents value.
+
+The discover_author function can return one of two values:
+
+- An author name (i.e. "James").
+- The h-card of an author.
+
+These are the two outputs defined in the authorship inference algorithm. Your program should be able to handle both of these outputs.
+
+This code returns the following h-card:
+
+.. code-block:: python
+
+    {
+        'type': ['h-card'],
+        'properties': {
+            'url': ['https://aaronparecki.com/'],
+            'name': ['Aaron Parecki'],
+            'photo': ['https://aaronparecki.com/images/profile.jpg']
+        },
+        'value': 'https://aaronparecki.com/'
+    }
+
+
+Find a post type
+------------------------
+
+To find the post type associated with a web page, you can use the `get_post_type` function.
+
+The `get_post_type` function function uses the following syntax:
+
+.. autofunction:: indieweb_utils.get_post_type
+
+This function returns a single string with the post type of the specified web page.
+
+See the `Post Type Discovery specification <https://indieweb.org/post-type-discovery>`_ for a full list of post types.
+
+
+Find the original version of a post
+------------------------------------
+
+To find the original version of a post per the Original Post Discovery algorithm, use this code:
+
+.. autofunction:: indieweb_utils.discover_original_post
+
+This function returns the URL of the original version of a post, if one is found. Otherwise, None is returned.
+
+
+Find all feeds on a page
+-----------------------------
+
+To discover the feeds on a page, use this function:
+
+.. autofunction:: indieweb_utils.discover_web_page_feeds
+
+This function returns a list with all feeds on a page.
+
+Each feed is structured as a FeedUrl object. FeedUrl objects contain the following attributes:
+
+.. autoclass:: indieweb_utils.FeedUrl

--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -1,5 +1,5 @@
-IndieAuth Features
-=================================
+IndieAuth
+==========
 
 The indieweb-utils library provides a number of helper functions that will enable you
 to implement your own IndieAuth authentication and token endpoints in Python.
@@ -53,8 +53,33 @@ Usage information for this function is below.
 
 .. autofunction:: indieweb_utils.get_profile
 
-Generate an authentication token
+
+
+Retrieve Valid Links for Use in RelMeAuth
+-----------------------------------------
+
+To authenticate a user with `RelMeAuth <https://microformats.org/RelMeAuth>`_, you need to validate that there is a two-way link between two resources.
+
+IndieWeb Utils implements a helper function that checks whether the URLs linked with rel=me on a web page contain a
+link back to the source.
+
+To check whether there is a two-way rel=me link between two resources, you can use this function:
+
+.. autofunction:: indieweb_utils.get_valid_relmeauth_links
+
+This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
+rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
+if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user, even if the `get_valid_relmeauth_links()` function found a valid two-way rel=me link.
+
+
+IndieAuth Endpoint Scaffolding
 --------------------------------
+
+indieweb-utils includes a `indieauth.server` module with scaffolding to help you build your own IndieAuth endpoints.
+
+
+Generate an authentication token
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `generate_auth_token()` function validates that an authentication request contains all required values. Then,
 this function generates a JWT-encoded token with the following pieces of information:
@@ -80,7 +105,7 @@ perhaps in session storage, for later use in checking the validity of a token re
 request.
 
 Validate an authorization response
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `_validate_indieauth_response` function contains five checks. These five checks validate an authorization response according to the IndieAuth specification.
 
@@ -101,7 +126,7 @@ This function does not return a value if an authorization response is valid. If 
 an exception will be raised with a relevant error message.
 
 Redeem an IndieAuth code at a token endpoint
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can redeem an IndieAuth authorization code for an access token if needed. This is a common
 need for Micropub and Microsub clients.
@@ -122,8 +147,9 @@ Here is the syntax for this function:
 
 .. autofunction:: indieweb_utils.redeem_code
 
+
 Validate an access token created by a token endpoint
-----------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A server may ask your token endpoint to validate that a provided token is in fact valid. This may be done
 by a Micropub client to ensure a token is still active, for example.
@@ -139,18 +165,50 @@ Here is the syntax for the function:
 
 .. autofunction:: indieweb_utils.validate_access_token
 
-Retrieve Valid Links for Use in RelMeAuth
------------------------------------------
+Determine if a user is authenticated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To authenticate a user with `RelMeAuth <https://microformats.org/RelMeAuth>`_, you need to validate that there is a two-way link between two resources.
+To check if a user is authenticated in a Flask application, use the following function:
 
-IndieWeb Utils implements a helper function that checks whether the URLs linked with rel=me on a web page contain a
-link back to the source.
+.. autofunction:: indieweb_utils.is_authenticated
 
-To check whether there is a two-way rel=me link between two resources, you can use this function:
+This function checks if an authorization token is provided in a header or user storage. If a token is provided, that token is verified with the specified token endpoint.
 
-.. autofunction:: indieweb_utils.get_valid_relmeauth_links
+A True value is returned if a user has provided a token and that token is valid. A False value is returned if a user has not provided a token or if the token is invalid.
 
-This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
-rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
-if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user, even if the `get_valid_relmeauth_links()` function found a valid two-way rel=me link.
+
+Handle an IndieAuth callback request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The last stage of the IndieAuth authentication flow for a client is to verify a callback response and exchange the provided code with a token.
+
+This function implements a callback handler to verify the response frmo an authorization server and redeem a token.
+
+To use this function, you need to pass in the following arguments:
+
+.. autofunction:: indieweb_utils.indieauth_callback_handler
+
+This function verifies that an authorization server has returned a valid response and redeems a token.
+
+You can leave the "me" value equal to None if any URL should be able to access your service.
+
+Otherwise, set "me" to the URL of the profile that should be able to access your service.
+
+Setting a me value other than None may be useful if you are building personal services that nobody else should be able to access.
+
+If successful, this function returns an IndieAuthCallbackResponse object that looks like this:
+
+.. class:: indieweb_utils.IndieAuthCallbackResponse
+
+This class contains an endpoint_response value. This value is equal to the JSON response sent by the IndieAuth web server.
+
+An example endpoint response looks like this:
+
+.. code-block:: python
+
+    {
+        "me": "https://jamesg.blog/",
+        "access_token": "ACCESS_TOKEN",
+        "scope": "SCOPE_LIST"
+    }
+

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -56,18 +56,6 @@ By default, this function contains all of the attributes in the Post Type Discov
 
 Custom properties are added to the end of the post type discovery list, just before the "article" property. All specification property types are checked before your custom attribute.
 
-Discover a Webmention Endpoint
-------------------------------------
-
-Webmention endpoint discovery is useful if you want to know if you can send webmentions to a site or if you want to send a webmention to a site.
-
-You can discover if a URL has an associated webmention endpoint using the `discover_webmention_endpoint` function:
-
-.. autofunction:: indieweb_utils.discover_webmention_endpoint
-
-If successful, this function returns the URL of the webmention endpoint associated with a resource. In this case, the message value is a blank string.
-
-If a webmention endpoint could not be found, URL is equal to None. In this case, a string message value is provided that you can use for debugging or present to a user.
 
 Canonicalize a URL
 ------------------------
@@ -195,16 +183,6 @@ To find the original version of a post per the Original Post Discovery algorithm
 
 This function returns the URL of the original version of a post, if one is found. Otherwise, None is returned.
 
-Send a Webmention
-------------------
-
-To send a webmention to a target, use this function:
-
-.. autofunction:: indieweb_utils.send_webmention
-
-This function returns a SendWebmentionResponse object with this structure:
-
-.. autoclass:: indieweb_utils.SendWebmentionResponse
 
 Discover all Feeds on a Page
 -----------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -20,18 +20,6 @@ You can import the package using the following line of code:
 
     import indieweb_utils
 
-Find a Post Type
-------------------------
-
-To find the post type associated with a web page, you can use the `get_post_type` function.
-
-The `get_post_type` function function uses the following syntax:
-
-.. autofunction:: indieweb_utils.get_post_type
-
-This function returns a single string with the post type of the specified web page.
-
-See the `Post Type Discovery specification <https://indieweb.org/post-type-discovery>`_ for a full list of post types.
 
 Custom Properties
 ------------------------
@@ -76,46 +64,6 @@ A complete URL returned by this function looks like this:
 
     https://indieweb.org/POSSE
 
-Discover an Article Author
-------------------------------------
-
-You can discover the original author of an article as per the Authorship Specification.
-
-To do so, use this function:
-
-.. autofunction:: indieweb_utils.discover_author
-
-Here are the arguments you can use:
-
-- `url`: The URL of the web page whose author you want to discover.
-- `page_contents`: The unmodified HTML of a web page whose author you want to discover.
-
-The page_contents argument is optional.
-
-If no page_contents argument is specified, the URL you stated is retrieved. Then, authorship inference begins.
-
-If you specify a page_contents value, the HTML you parsed is used for authorship discovery. This saves on a HTML request if you have already retrieved the HTML for another reason (for example, if you need to retreive other values in the page HTML). You still need to specify a URL even if you specify a page_contents value.
-
-The discover_author function can return one of two values:
-
-- An author name (i.e. "James").
-- The h-card of an author.
-
-These are the two outputs defined in the authorship inference algorithm. Your program should be able to handle both of these outputs.
-
-This code returns the following h-card:
-
-.. code-block:: python
-
-    {
-        'type': ['h-card'],
-        'properties': {
-            'url': ['https://aaronparecki.com/'],
-            'name': ['Aaron Parecki'],
-            'photo': ['https://aaronparecki.com/images/profile.jpg']
-        },
-        'value': 'https://aaronparecki.com/'
-    }
 
 Handle an IndieAuth Callback Request
 ------------------------------------
@@ -174,36 +122,3 @@ This function returns a ReplyContext object that looks like this:
 
 .. autoclass:: indieweb_utils.ReplyContext
 
-Find the Original Version of a Post
-------------------------------------
-
-To find the original version of a post per the Original Post Discovery algorithm, use this code:
-
-.. autofunction:: indieweb_utils.discover_original_post
-
-This function returns the URL of the original version of a post, if one is found. Otherwise, None is returned.
-
-
-Discover all Feeds on a Page
------------------------------
-
-To discover the feeds on a page, use this function:
-
-.. autofunction:: indieweb_utils.discover_web_page_feeds
-
-This function returns a list with all feeds on a page.
-
-Each feed is structured as a FeedUrl object. FeedUrl objects contain the following attributes:
-
-.. autoclass:: indieweb_utils.FeedUrl
-
-Get a Representative h-card
----------------------------
-
-To find the h-card that is considered representative of a web resource per the
-`Representative h-card Parsing Algorithm <https://microformats.org/wiki/representative-h-card-parsing>`_,
-use the following function:
-
-.. autofunction:: indieweb_utils.get_representative_h_card
-
-This function returns a dictionary with the h-card found on a web page.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -65,52 +65,6 @@ A complete URL returned by this function looks like this:
     https://indieweb.org/POSSE
 
 
-Handle an IndieAuth Callback Request
-------------------------------------
-
-The last stage of the IndieAuth authentication flow for a client is to verify a callback response and exchange the provided code with a token.
-
-This function implements a callback handler to verify the response frmo an authorization server and redeem a token.
-
-To use this function, you need to pass in the following arguments:
-
-.. autofunction:: indieweb_utils.indieauth_callback_handler
-
-This function verifies that an authorization server has returned a valid response and redeems a token.
-
-You can leave the "me" value equal to None if any URL should be able to access your service.
-
-Otherwise, set "me" to the URL of the profile that should be able to access your service.
-
-Setting a me value other than None may be useful if you are building personal services that nobody else should be able to access.
-
-If successful, this function returns an IndieAuthCallbackResponse object that looks like this:
-
-.. class:: indieweb_utils.IndieAuthCallbackResponse
-
-This class contains an endpoint_response value. This value is equal to the JSON response sent by the IndieAuth web server.
-
-An example endpoint response looks like this:
-
-.. code-block:: python
-
-    {
-        "me": "https://jamesg.blog/",
-        "access_token": "ACCESS_TOKEN",
-        "scope": "SCOPE_LIST"
-    }
-
-Check if a User is Authenticated (Flask)
-----------------------------------------
-
-To check if a user is authenticated in a Flask application, use the following function:
-
-.. autofunction:: indieweb_utils.is_authenticated
-
-This function checks if an authorization token is provided in a header or user storage. If a token is provided, that token is verified with the specified token endpoint.
-
-A True value is returned if a user has provided a token and that token is valid. A False value is returned if a user has not provided a token or if the token is invalid.
-
 Generate Reply Context
 ------------------------
 

--- a/docs/source/webmention.rst
+++ b/docs/source/webmention.rst
@@ -1,0 +1,28 @@
+Webmention
+===========
+
+
+Discover a Webmention Endpoint
+------------------------------------
+
+Webmention endpoint discovery is useful if you want to know if you can send webmentions to a site or if you want to send a webmention to a site.
+
+You can discover if a URL has an associated webmention endpoint using the `discover_webmention_endpoint` function:
+
+.. autofunction:: indieweb_utils.discover_webmention_endpoint
+
+If successful, this function returns the URL of the webmention endpoint associated with a resource. In this case, the message value is a blank string.
+
+If a webmention endpoint could not be found, URL is equal to None. In this case, a string message value is provided that you can use for debugging or present to a user.
+
+
+Send a Webmention
+------------------
+
+To send a webmention to a target, use this function:
+
+.. autofunction:: indieweb_utils.send_webmention
+
+This function returns a SendWebmentionResponse object with this structure:
+
+.. autoclass:: indieweb_utils.SendWebmentionResponse


### PR DESCRIPTION
This PR attempts to organize the docs in a bit more user friendly way, rather than having one long usage page.

* Extract webmentions to its own section
* Extract discovery to its own section
* Collect the flask scaffolding under a common heading in the IndieAuth section