### PR TITLE
Create new url summary function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,4 +87,5 @@ Contributors
 
 - `capjamesg <https://github.com/capjamesg>`_
 - `tantek <https://github.com/tantek>`_
-- `jamesvandyne <https://github.com/jamesvandyne/>`_
+- `jamesvandyne <https://github.com/jamesvandyne>`_
+- `angelogladding <https://github.com/angelogladding>`_

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -20,31 +20,6 @@ You can import the package using the following line of code:
 
     import indieweb_utils
 
-
-Custom Properties
-------------------------
-
-The structure of the custom properties tuple is:
-
-.. code-block:: python
-
-   (attribute_to_look_for, value_to_return)
-
-An example custom property value is:
-
-.. code-block:: python
-
-    custom_properties = [
-        ("poke-of", "poke")
-    ]
-
-This function would look for a poke-of attribute on a web page and return the "poke" value.
-
-By default, this function contains all of the attributes in the Post Type Discovery mechanism.
-
-Custom properties are added to the end of the post type discovery list, just before the "article" property. All specification property types are checked before your custom attribute.
-
-
 Canonicalize a URL
 ------------------------
 
@@ -76,3 +51,31 @@ This function returns a ReplyContext object that looks like this:
 
 .. autoclass:: indieweb_utils.ReplyContext
 
+
+Generate a URL Summary
+----------------------
+
+You can generate a summary of a URL without retrieving the page using the `get_url_summary` function.
+
+By default, this function can generate a summary for the following URLs:
+
+- github.com
+- twitter.com
+- facebook.com
+- eventbrite.com / eventbrite.co.uk
+- upcoming.com
+- calagator.com
+- events.indieweb.org
+
+.. autofunction:: indieweb_utils.get_url_summary
+
+You can specify custom mappings for other domains using the `custom_mappings` parameter.
+
+This parameter accepts a dictionary of domain names to summaries, like this:
+
+    {
+        "example.com": "A post on example.com.",
+        "meetup.com": "A meetup on meetup.com."
+    }
+
+If a summary cannot be generated, this function returns "A post by [domain_name].", where domain name is the domain of the URL you passed into the function.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -60,21 +60,22 @@ By default, this function can generate a summary for the following URLs:
 
 - github.com
 - twitter.com
-- facebook.com
 - eventbrite.com / eventbrite.co.uk
 - upcoming.com
 - calagator.com
 - events.indieweb.org
+- indieweb.org
 
 .. autofunction:: indieweb_utils.get_url_summary
 
 You can specify custom mappings for other domains using the `custom_mappings` parameter.
 
-This parameter accepts a dictionary of domain names to summaries, like this:
+This parameter accepts a dictionary of with domain names mapped to lists of tuples with patterns to match and strings to return, like this:
 
     {
-        "example.com": "A post on example.com.",
-        "meetup.com": "A meetup on meetup.com."
+        "example.com": [
+            (r"example.com/(\d+)", "Example #{}"),
+        ]
     }
 
 If a summary cannot be generated, this function returns "A post by [domain_name].", where domain name is the domain of the URL you passed into the function.

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -19,7 +19,7 @@ from .utils.url_summary import InvalidURL, get_url_summary
 from .utils.urls import canonicalize_url
 from .webmentions import (
     SendWebmentionResponse,
-    discover_endpoint,
+    discover_endpoints,
     discover_webmention_endpoint,
     send_webmention,
     validate_webmention,
@@ -53,5 +53,5 @@ __all__ = [
     "validate_authorization_response",
     "get_url_summary",
     "InvalidURL",
-    "discover_endpoint",
+    "discover_endpoints",
 ]

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -15,6 +15,7 @@ from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handl
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context
+from .utils.url_summary import InvalidURL, get_url_summary
 from .utils.urls import canonicalize_url
 from .webmentions import (
     SendWebmentionResponse,
@@ -49,4 +50,6 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "get_url_summary",
+    "InvalidURL",
 ]

--- a/src/indieweb_utils/utils/__init__.py
+++ b/src/indieweb_utils/utils/__init__.py
@@ -1,3 +1,4 @@
+from .url_summary import InvalidURL, get_url_summary
 from .urls import _is_http_url, canonicalize_url
 
-__all__ = ["canonicalize_url", "_is_http_url"]
+__all__ = ["canonicalize_url", "_is_http_url", "get_url_summary", "InvalidURL"]

--- a/src/indieweb_utils/utils/url_summary.py
+++ b/src/indieweb_utils/utils/url_summary.py
@@ -1,0 +1,114 @@
+from urllib import parse as url_parse
+
+class InvalidURL(Exception):
+    """
+    URL cannot be parsed to retrieve a summary.
+    """
+    pass
+
+def _get_path_sections(path: str) -> list:
+    """
+    Get a list of all the items in a URL path.
+    """
+
+    path_sections = path.split("/")
+
+    # remove blank values from list
+    path_sections.remove("")
+
+    if len(path_sections) == 0:
+        return []
+
+    return path_sections
+
+
+def _github_auto_summary(path: str) -> str:
+    """
+    Retrieve the summary of a GitHub URL.
+    """
+
+    path_sections = _get_path_sections(path)
+
+    project_name = path_sections[1]
+
+    if len(path_sections) > 2:
+        page_type = path_sections[2]
+
+        if page_type == "issues":
+            return "A comment on issue " + path_sections[3] + " in the " + project_name + " repository."
+        elif page_type == "pull":
+            return "A comment on pull request " + path_sections[3] + " in the " + project_name + " repository."
+
+    return "A comment on GitHub in the " + project_name + " repository."
+
+
+def _social_network_url_summaries(domain: str, path: str) -> str:
+    """
+    Retrieve the summary of a social network URL.
+    """
+
+    path_sections = _get_path_sections(path)
+
+    if domain in ("eventbrite.com", "eventbrite.co.uk"):
+        return "An Eventbrite event."
+    elif domain == "upcoming.com":
+        return "An Upcoming event."
+    elif domain == "calagator.com":
+        return "A Calagator event."
+    elif domain == "events.indieweb.org":
+        return "An IndieWeb event."
+    elif domain == "twitter.com":
+        return "A Tweet from @" + path_sections[0] + "."
+
+    return ""
+
+
+def get_url_summary(url: str, custom_mappings: dict = {}) -> str:
+    """
+    Retrieve a sentence summarising the contents of a URL, based on the auto_url_summary function in CASSIS.
+
+    :refs: https://indieweb.org/auto-url-summary:
+    :refs: https://github.com/tantek/cassis/blob/master/cassis-lab.php#L52:
+
+    :param url: The URL whose summary you want to retrieve.
+    :type url: str
+
+    :return: The summary of the URL.
+    :rtype: str
+
+    .. code-block:: python
+
+        import indieweb_utils
+
+        url_summary = indieweb_utils.get_url_summary(
+            "https://github.com/capjamesg/indieweb-utils/issues/56"
+        )
+
+        print(url_summary)
+
+    :raises InvalidURL: The URL cannot be parsed to retrieve a summary.
+    """
+
+    parsed_url = url_parse.urlsplit(url)
+
+    domain = parsed_url.netloc
+    path = parsed_url.path
+
+    if domain == "":
+        raise InvalidURL("The URL cannot be parsed to retrieve a summary.")
+
+    # remove www from beginning of a domain
+    domain = domain.lstrip("www.")
+
+    if domain == "github.com":
+        return _github_auto_summary(path)
+
+    social_network_response = _social_network_url_summaries(domain, path)
+
+    if social_network_response != "":
+        return social_network_response
+
+    if custom_mappings.get(domain) is not None:
+        return custom_mappings.get(domain)
+
+    return "A post by " + domain + "."

--- a/src/indieweb_utils/utils/url_summary.py
+++ b/src/indieweb_utils/utils/url_summary.py
@@ -2,6 +2,7 @@ import re
 from urllib.parse import urlparse
 
 from .url_summary_templates import URL_SUMMARY_TEMPLATES
+from .urls import canonicalize_url
 
 
 class InvalidURL(Exception):
@@ -22,7 +23,9 @@ def get_url_summary(url: str, custom_templates: list = None):
     :return: A summary of the URL.
     :rtype: str
 
-    import indieweb_utils
+    .. code-block:: python
+
+        import indieweb_utils
 
         # a dictionary of custom patterns against which to match during the lookup
         custom_properties = {
@@ -40,11 +43,15 @@ def get_url_summary(url: str, custom_templates: list = None):
         print(summary) # "A map of london coffee shops on jamesg.blog"
     """
 
+    url = canonicalize_url(url)
+
     if custom_templates is None:
         custom_templates = []
 
     parsed_url = urlparse(url)
     domain = parsed_url.netloc
+
+    domain = domain.lstrip("www.")
 
     if not domain:
         raise InvalidURL("The provided URL is incorrectly formatted.")

--- a/src/indieweb_utils/utils/url_summary_templates.py
+++ b/src/indieweb_utils/utils/url_summary_templates.py
@@ -1,0 +1,58 @@
+URL_SUMMARY_TEMPLATES = {
+    "github.com": [
+        (
+            r"(?P<user>.+)/(?P<project>.+)/issues/(?P<issue>\d+)",
+            "A comment on issue #{issue} in the {project} GitHub repository",
+        ),
+        (
+            r"(?P<user>.+)/(?P<project>.+)/pull/(?P<pull>\d+)",
+            "A comment on pull request #{pull} in the {project} GitHub repository",
+        ),
+        (
+            r"(?P<user>.+)/(?P<project>.+)",
+            "A comment on the {project} GitHub repository",
+        ),
+    ],
+    "twitter.com": [
+        (
+            r"(?P<user>[^/]+)",
+            "A tweet by @{user}",
+        ),
+    ],
+    "upcoming.com": [
+        (
+            "",
+            "An event on Upcoming",
+        )
+    ],
+    "eventbrite.com": [
+        (
+            "",
+            "An event on Eventbrite",
+        )
+    ],
+    "eventbrite.co.uk": [
+        (
+            "",
+            "An event on Eventbrite",
+        )
+    ],
+    "calagator.com": [
+        (
+            "",
+            "An event on Calagator",
+        )
+    ],
+    "events.indieweb.org": [
+        (
+            "",
+            "An event on IndieWeb events",
+        )
+    ],
+    "indieweb.org": [
+        (
+            r"(?P<page>.+)",
+            "The /{page} page on the IndieWeb wiki",
+        )
+    ],
+}

--- a/src/indieweb_utils/utils/urls.py
+++ b/src/indieweb_utils/utils/urls.py
@@ -1,7 +1,7 @@
 from urllib import parse as url_parse
 
 
-def canonicalize_url(url: str, domain: str, full_url: str = "", protocol: str = "https") -> str:
+def canonicalize_url(url: str, domain: str = "", full_url: str = "", protocol: str = "https") -> str:
     """
     Return a canonical URL for the given URL.
 

--- a/src/indieweb_utils/webmentions/__init__.py
+++ b/src/indieweb_utils/webmentions/__init__.py
@@ -1,4 +1,4 @@
-from .discovery import discover_endpoint, discover_webmention_endpoint
+from .discovery import discover_endpoints, discover_webmention_endpoint
 from .send import SendWebmentionResponse, send_webmention
 from .validate import validate_webmention
 
@@ -7,5 +7,5 @@ __all__ = [
     "validate_webmention",
     "discover_webmention_endpoint",
     "SendWebmentionResponse",
-    "discover_endpoint",
+    "discover_endpoints",
 ]

--- a/tests/test_utils/test_url_summary.py
+++ b/tests/test_utils/test_url_summary.py
@@ -8,29 +8,32 @@ from indieweb_utils import utils
     [
         (
             "https://github.com/capjamesg/indieweb-utils/issues/58",
-            "A comment on issue 58 in the indieweb-utils repository.",
+            "A comment on issue #58 in the indieweb-utils GitHub repository",
         ),
         (
             "https://github.com/capjamesg/indieweb-utils/pull/62",
-            "A comment on pull request 62 in the indieweb-utils repository.",
+            "A comment on pull request #62 in the indieweb-utils GitHub repository",
         ),
         (
             "https://github.com/capjamesg/indieweb-utils",
-            "A comment on GitHub in the indieweb-utils repository.",
+            "A comment on the indieweb-utils GitHub repository",
         ),
         (
-            "https://www.eventbrite.co.uk/e/prewired-registration-15338031465",
-            "An Eventbrite event.",
+            "https://eventbrite.co.uk/e/prewired-registration-15338031465",
+            "An event on Eventbrite",
         ),
         (
             "https://events.indieweb.org/2022/10/homebrew-website-club-europe-london-AInXEh6WBbqn",
-            "An IndieWeb event.",
+            "An event on IndieWeb events",
         ),
         (
             "https://twitter.com/jack/status/20",
-            "A Tweet from @jack.",
+            "A tweet by @jack",
         ),
-        ("https://jamesg.blog", "A post by jamesg.blog."),
+        ("https://jamesg.blog", "A post by jamesg.blog"),
+        ("https://indieweb.org/coffee", "The /coffee page on the IndieWeb wiki"),
+        ("https://calagator.com/event", "An event on Calagator"),
+        ("https://upcoming.com/event", "An event on Upcoming"),
     ],
 )
 def test_canonicalize_url(url, expected):

--- a/tests/test_utils/test_url_summary.py
+++ b/tests/test_utils/test_url_summary.py
@@ -15,6 +15,10 @@ from indieweb_utils import utils
             "A comment on pull request #62 in the indieweb-utils GitHub repository",
         ),
         (
+            "https://www.github.com/capjamesg/indieweb-utils",
+            "A comment on the indieweb-utils GitHub repository",
+        ),
+        (
             "https://github.com/capjamesg/indieweb-utils",
             "A comment on the indieweb-utils GitHub repository",
         ),
@@ -32,6 +36,7 @@ from indieweb_utils import utils
         ),
         ("https://jamesg.blog", "A post by jamesg.blog"),
         ("https://indieweb.org/coffee", "The /coffee page on the IndieWeb wiki"),
+        ("https://www.indieweb.org/coffee", "The /coffee page on the IndieWeb wiki"),
         ("https://calagator.com/event", "An event on Calagator"),
         ("https://upcoming.com/event", "An event on Upcoming"),
     ],

--- a/tests/test_utils/test_url_summary.py
+++ b/tests/test_utils/test_url_summary.py
@@ -1,0 +1,43 @@
+import pytest
+
+from indieweb_utils import utils
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            "https://github.com/capjamesg/indieweb-utils/issues/58",
+            "A comment on issue 58 in the indieweb-utils repository.",
+        ),
+        (
+            "https://github.com/capjamesg/indieweb-utils/pull/62",
+            "A comment on pull request 62 in the indieweb-utils repository.",
+        ),
+        (
+            "https://github.com/capjamesg/indieweb-utils",
+            "A comment on GitHub in the indieweb-utils repository.",
+        ),
+        (
+            "https://www.eventbrite.co.uk/e/prewired-registration-15338031465",
+            "An Eventbrite event.",
+        ),
+        (
+            "https://events.indieweb.org/2022/10/homebrew-website-club-europe-london-AInXEh6WBbqn",
+            "An IndieWeb event.",
+        ),
+        (
+            "https://twitter.com/jack/status/20",
+            "A Tweet from @jack.",
+        ),
+        ("https://jamesg.blog", "A post by jamesg.blog."),
+    ],
+)
+def test_canonicalize_url(url, expected):
+    assert utils.get_url_summary(url=url) == expected
+
+
+def test_invalid_url():
+    # make sure invalid URL raises an error
+    with pytest.raises(utils.InvalidURL):
+        utils.get_url_summary(url="jamesg")


### PR DESCRIPTION
This PR implements an [auto URL summary](https://indieweb.org/auto-url-summary) function that produces a one-sentence summary of the contents of given URLs.

The PR includes various rules derived from the [CASSIS auto_url_summary](https://github.com/tantek/cassis/blob/master/cassis-lab.php#L52) function, implemented after discussion with @tantek on the usefulness of auto URL summaries.

This PR includes documentation and a test suite to accompany the function.