### PR TITLE
Add TicketAuth redemption functions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ project = "IndieWeb Utils"
 copyright = "capjamesg 2022"
 author = "capjamesg"
 
-sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, os.path.abspath("../../src/"))
 
 release = "0.2.0"
 version = "0.2.0"

--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -154,3 +154,4 @@ To check whether there is a two-way rel=me link between two resources, you can u
 This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
 rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
 if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user, even if the `get_valid_relmeauth_links()` function found a valid two-way rel=me link.
+

--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -106,7 +106,7 @@ Redeem an IndieAuth code at a token endpoint
 You can redeem an IndieAuth authorization code for an access token if needed. This is a common
 need for Micropub and Microsub clients.
 
-The `redeem_code()`` function validates all the required parameters are provided in a request. Then,
+The `redeem_code()` function validates all the required parameters are provided in a request. Then,
 this function decodes the provided code using the code, secret key, and algorithm specified. If
 the code is invalid or the code challenge in the decoded code is invalid, AuthenticationErrors will be
 raised. The function will also verify that:

--- a/docs/source/ticketauth.rst
+++ b/docs/source/ticketauth.rst
@@ -1,0 +1,22 @@
+TicketAuth Features (Experimental)
+==================================
+
+IndieWeb Utils has experimental helper functions for the "Issue an access token" scetion of the TicketAuth draft specification.
+
+While the TicketAuth specification is a draft, there are implementations following the specification.
+
+The mechanics of these functions may change as TicketAuth becomes a more mature specification.
+
+Create an IndieAuth ticket
+-------------------------
+
+The `create_ticket()` function discovers the ticket endpoint of a subject and makes a POST request to their ticket endpoint.
+
+This POST request contains an `application/x-www-form-urlencoded` payload with ticket, resource, and subject values. These are defined in Step 2 of the TicketAuth specification.
+
+This function will return nothing if the POST request was successful. This is because a ticket endpoint does not return any value when the POST request is made. If the request fails, this function will raise an exception.
+
+Redeem a ticket for an access token
+-----------------------------------
+
+The `redeem_ticket()` function redeems a ticket for an access token from a ticket endpoint.

--- a/docs/source/ticketauth.rst
+++ b/docs/source/ticketauth.rst
@@ -7,10 +7,10 @@ While the TicketAuth specification is a draft, there are implementations followi
 
 The mechanics of these functions may change as TicketAuth becomes a more mature specification.
 
-Create an IndieAuth ticket
--------------------------
+Send a IndieAuth ticket to a server
+-----------------------------------
 
-The `create_ticket()` function discovers the ticket endpoint of a subject and makes a POST request to their ticket endpoint.
+The `send_ticket()` function discovers the ticket endpoint of a subject and makes a POST request to their ticket endpoint.
 
 This POST request contains an `application/x-www-form-urlencoded` payload with ticket, resource, and subject values. These are defined in Step 2 of the TicketAuth specification.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -148,11 +148,7 @@ Otherwise, set "me" to the URL of the profile that should be able to access your
 
 Setting a me value other than None may be useful if you are building personal services that nobody else should be able to access.
 
-If successful, this function returns an IndieAuthCallbackResponse object that looks like this:
-
-.. class:: indieweb_utils.IndieAuthCallbackResponse
-
-This class contains an endpoint_response value. This value is equal to the JSON response sent by the IndieAuth web server.
+If successful, this function returns an IndieAuthCallbackResponse. This class contains an `endpoint_response`` value. This value is equal to the JSON response sent by the IndieAuth web server.
 
 An example endpoint response looks like this:
 
@@ -201,10 +197,6 @@ Send a Webmention
 To send a webmention to a target, use this function:
 
 .. autofunction:: indieweb_utils.send_webmention
-
-This function returns a SendWebmentionResponse object with this structure:
-
-.. autoclass:: indieweb_utils.SendWebmentionResponse
 
 Discover all Feeds on a Page
 -----------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -97,13 +97,6 @@ To do so, use this function:
 
 .. autofunction:: indieweb_utils.discover_author
 
-Here are the arguments you can use:
-
-- `url`: The URL of the web page whose author you want to discover.
-- `page_contents`: The unmodified HTML of a web page whose author you want to discover.
-
-The page_contents argument is optional.
-
 If no page_contents argument is specified, the URL you stated is retrieved. Then, authorship inference begins.
 
 If you specify a page_contents value, the HTML you parsed is used for authorship discovery. This saves on a HTML request if you have already retrieved the HTML for another reason (for example, if you need to retreive other values in the page HTML). You still need to specify a URL even if you specify a page_contents value.

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -1,6 +1,6 @@
 # Imports added for API backwards compatibility
 
-from .feeds import FeedUrl, discover_web_page_feeds
+from .feeds import FeedUrl, discover_h_feed, discover_web_page_feeds
 from .indieauth import (
     _validate_indieauth_response,
     get_h_app_item,
@@ -10,6 +10,7 @@ from .indieauth import (
     redeem_code,
     validate_access_token,
     validate_authorization_response,
+    generate_auth_token
 )
 from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handler
 from .posts.discovery import discover_author, discover_original_post, get_post_type
@@ -50,4 +51,6 @@ __all__ = [
     "get_valid_relmeauth_links",
     "validate_authorization_response",
     "autolink_tags",
+    "discover_h_feed",
+    "generate_auth_token"
 ]

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -15,7 +15,7 @@ from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handl
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context
-from .utils.urls import canonicalize_url
+from .utils import autolink_tags, canonicalize_url
 from .webmentions import (
     SendWebmentionResponse,
     discover_webmention_endpoint,
@@ -49,4 +49,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "autolink_tags",
 ]

--- a/src/indieweb_utils/feeds/__init__.py
+++ b/src/indieweb_utils/feeds/__init__.py
@@ -1,3 +1,3 @@
-from .discovery import FeedUrl, discover_web_page_feeds
+from .discovery import FeedUrl, discover_web_page_feeds, discover_h_feed
 
-__all__ = ["discover_web_page_feeds", "FeedUrl"]
+__all__ = ["discover_web_page_feeds", "FeedUrl", "discover_h_feed"]

--- a/src/indieweb_utils/indieauth/__init__.py
+++ b/src/indieweb_utils/indieauth/__init__.py
@@ -1,12 +1,12 @@
 from .flask import (
     _validate_indieauth_response,
     indieauth_callback_handler,
-    is_authenticated,
+    is_authenticated
 )
 from .happ import get_h_app_item
 from .profile import get_profile
 from .relmeauth import get_valid_relmeauth_links
-from .server import redeem_code, validate_access_token, validate_authorization_response
+from .server import redeem_code, validate_access_token, validate_authorization_response, generate_auth_token
 
 __all__ = [
     "is_authenticated",
@@ -18,4 +18,5 @@ __all__ = [
     "_validate_indieauth_response",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "generate_auth_token",
 ]

--- a/src/indieweb_utils/indieauth/server.py
+++ b/src/indieweb_utils/indieauth/server.py
@@ -218,7 +218,7 @@ def generate_auth_token(
         import string
 
         try:
-            token = indieweb_utils.indieauth.server.generate_auth_token(
+            token = indieweb_utils.generate_auth_token(
                 me="https://test.example.com/user",
                 client_id="https://example.com",
                 redirect_uri="https://example.com/callback",

--- a/src/indieweb_utils/indieauth/ticketauth.py
+++ b/src/indieweb_utils/indieauth/ticketauth.py
@@ -27,13 +27,23 @@ class TicketCreationError(Exception):
     """
 
 
-def create_ticket(feed_url: str, ticket: str, subject: str, resource: str) -> None:
+def send_ticket(subject: str, ticket: str, resource: str) -> None:
     """
-    Create a ticket for an IndieAuth ticket server.
+    Send a ticket to a IndieAuth ticket server.
 
+    :param subject: The subject of the TicketAuth interaction.
+    :type subject: str
+    :param ticket: The ticket to send.
+    :type ticket: str
+    :param resource: The resource to which the ticket grants access.
+    :type resource: str
+    :return: None
+
+    :raises NoTicketEndpointFound: A ticket endpoint could not be found for the provided resource.
+    :raises TicketCreationError: There was an error creating a ticket.
     """
 
-    url_endpoints = _discover_endpoints(feed_url, ["ticket_endpoint"])
+    url_endpoints = _discover_endpoints(subject, ["ticket_endpoint"])
 
     if url_endpoints.get("ticket_endpoint") is None:
         raise NoTicketEndpointFound("A ticket endpoint was not found.")
@@ -52,6 +62,16 @@ def create_ticket(feed_url: str, ticket: str, subject: str, resource: str) -> No
 def redeem_ticket(resource: str, ticket: str) -> str:
     """
     Redeem a ticket from an IndieAuth ticket server for an access token.
+
+    :param resource: The URL of the resource whose token endpoint should be used in redemption.
+    :type resource: str
+    :param ticket: The ticket to redeem.
+    :type ticket: str
+    :return: The access token.
+    :rtype: str
+
+    :raises NoTokenEndpointFound: A token endpoint could not be found for the provided resource.
+    :raises TicketRedemptionError: There was an error redeeming a ticket.
     """
 
     url_endpoints = _discover_endpoints(resource, ["token_endpoint"])
@@ -69,6 +89,4 @@ def redeem_ticket(resource: str, ticket: str) -> str:
     if ticket_response.status_code != 200:
         raise TicketRedemptionError("The ticket endpoint returned a non-200 status code.")
 
-    link_results = ticket_response.json()
-
-    return link_results.json()["ticket"]
+    return ticket_response.json()["access_token"]

--- a/src/indieweb_utils/indieauth/ticketauth.py
+++ b/src/indieweb_utils/indieauth/ticketauth.py
@@ -1,0 +1,74 @@
+import requests
+
+from ..webmentions.discovery import _discover_endpoints
+
+
+class TicketRedemptionError(Exception):
+    """
+    A ticket cannot be redeemed.
+    """
+
+
+class NoTokenEndpointFound(Exception):
+    """
+    A token endpoint is not present on the provided page.
+    """
+
+
+class NoTicketEndpointFound(Exception):
+    """
+    A ticket endpoint is not present on the provided page.
+    """
+
+
+class TicketCreationError(Exception):
+    """
+    A ticket cannot be created.
+    """
+
+
+def create_ticket(feed_url: str, ticket: str, subject: str, resource: str) -> None:
+    """
+    Create a ticket for an IndieAuth ticket server.
+
+    """
+
+    url_endpoints = _discover_endpoints(feed_url, ["ticket_endpoint"])
+
+    if url_endpoints.get("ticket_endpoint") is None:
+        raise NoTicketEndpointFound("A ticket endpoint was not found.")
+
+    request_data = {"ticket": ticket, "resource": resource, "subject": subject}
+
+    try:
+        ticket_response = requests.post(url_endpoints["ticket_endpoint"], timeout=5, data=request_data)
+    except requests.exceptions.RequestException:
+        raise TicketCreationError("The ticket endpoint could not be accessed.")
+
+    if ticket_response.status_code not in (200, 202):
+        raise TicketCreationError("The ticket endpoint did not return a successful status code.")
+
+
+def redeem_ticket(resource: str, ticket: str) -> str:
+    """
+    Redeem a ticket from an IndieAuth ticket server for an access token.
+    """
+
+    url_endpoints = _discover_endpoints(resource, ["token_endpoint"])
+
+    if url_endpoints.get("token_endpoint") is None:
+        raise NoTokenEndpointFound("A token endpoint was not found.")
+
+    request_data = {"grant_type": "ticket", "ticket": ticket}
+
+    try:
+        ticket_response = requests.post(url_endpoints["token_endpoint"], timeout=5, data=request_data)
+    except requests.exceptions.RequestException:
+        raise TicketRedemptionError("The ticket endpoint could not be accessed.")
+
+    if ticket_response.status_code != 200:
+        raise TicketRedemptionError("The ticket endpoint returned a non-200 status code.")
+
+    link_results = ticket_response.json()
+
+    return link_results.json()["ticket"]

--- a/src/indieweb_utils/posts/discovery.py
+++ b/src/indieweb_utils/posts/discovery.py
@@ -177,6 +177,8 @@ def discover_author(url: str, page_contents: str = "") -> dict:
     """
     Discover the author of a post per the IndieWeb Authorship specification.
 
+    :refs: https://indieweb.org/authorship-spec
+
     :param url: The URL of the post.
     :type url: str
     :param page_contents: The optional page contents to use.

--- a/src/indieweb_utils/replies/context.py
+++ b/src/indieweb_utils/replies/context.py
@@ -18,6 +18,9 @@ from ..webmentions.discovery import (
 
 @dataclass
 class PostAuthor:
+    """
+    Information about the author of a post.
+    """
     name: str
     url: str
     photo: str
@@ -25,6 +28,9 @@ class PostAuthor:
 
 @dataclass
 class ReplyContext:
+    """
+    Context about a web page and its contents.
+    """
     webmention_endpoint: str
     post_url: str
     photo: str

--- a/src/indieweb_utils/utils/__init__.py
+++ b/src/indieweb_utils/utils/__init__.py
@@ -1,3 +1,4 @@
+from .autotag import autolink_tags
 from .urls import _is_http_url, canonicalize_url
 
-__all__ = ["canonicalize_url", "_is_http_url"]
+__all__ = ["canonicalize_url", "_is_http_url", "autolink_tags"]

--- a/src/indieweb_utils/utils/autotag.py
+++ b/src/indieweb_utils/utils/autotag.py
@@ -1,0 +1,77 @@
+import re
+from typing import Set
+
+
+def _match_tag(tag_prefix: str, match: str, user_tags: Set[str]) -> str:
+    """
+    Match a tag and return a link to the tag page.
+
+    :param tag_prefix: The prefix to append to the tag.
+    :type tag_prefix: str
+    :param match: The match to process.
+    :type match: str
+    :param user_tags: A set of tags that a user supports on their website.
+    :type user_tags: set
+    :return: The processed match.
+    :rtype: str
+    """
+    tag = match[1:]
+    if len(user_tags) > 0 and tag in user_tags:
+        return f"<a href='{tag_prefix}{tag}'>#{tag}</a>"
+    else:
+        return match
+
+
+def _match_person_tag(people: dict, match: str) -> str:
+    """
+    A person tag and return a link to their profile.
+
+    :param people: A dictionary of names to which a person tag can be matched.
+    :type people: dict
+    :param match: The match to process.
+    :type match: str
+    :return: The processed match.
+    :rtype: str
+    """
+    person = match[1:]
+    if people.get(person):
+        return f"<a href='{people[person][1]}'>{people[person][0]}</a>"
+    else:
+        return match
+
+
+def autolink_tags(text: str, tag_prefix: str, people: dict, tags: Set[str] = set()) -> str:
+    """
+    Replace hashtags (#) and person tags (@) with links to the respective tag page and profile URL.
+
+    :param text: The text to process.
+    :type text: str
+    :param tag_prefix: The prefic to append to identified tags.
+    :type tag_prefix: str
+    :param people: A dictionary of people to link to.
+    :type people: dict
+    :param tags: A set of tags to link to (optional).
+    :type tags: Set[str]
+    :return: The processed text.
+    :rtype: str
+
+    Example:
+
+    ..code-block:: python
+
+        import indieweb_utils
+
+        note = "I am working on a new #muffin #recipe with @jane"
+
+        people = {
+            "jane": ("Jane Doe", "https://jane.example.com") # tag to use, name of person, domain of person
+        }
+
+        note_with_tags = indieweb_utils.autolink_tags(note, "/tag/", people, tags=["muffin", "recipe"])
+
+    """
+
+    text = re.sub(r"#(\w+)", lambda match: _match_tag(tag_prefix, match.group(), tags), text)
+    text = re.sub(r"@(\w+)", lambda match: _match_person_tag(people, match.group()), text)
+
+    return text

--- a/src/indieweb_utils/webmentions/discovery.py
+++ b/src/indieweb_utils/webmentions/discovery.py
@@ -179,7 +179,6 @@ def _find_links_in_headers(*, headers, target_headers: List[str]) -> Dict[str, D
 
 
 def _find_links_html(*, body: str, target_headers: List[str]) -> Dict[str, str]:
-    """"""
     soup = BeautifulSoup(body, "html.parser")
     found: Dict[str, str] = {}
 

--- a/tests/test_utils/test_autotag.py
+++ b/tests/test_utils/test_autotag.py
@@ -1,0 +1,54 @@
+import pytest
+
+from indieweb_utils.utils import autolink_tags
+
+
+@pytest.mark.parametrize(
+    "text, tag_prefix, people, tags, expected",
+    [
+        (
+            "I am drinking a cup of #coffee this cool #October.",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "October"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool <a href='https://jamesg.blog/tag/October'>#October</a>.",  # noqa: E501
+        ),
+        (
+            "I am drinking a cup of #coffee this cool #October. #awesome",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "october"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool #October. #awesome",
+        ),
+        (
+            "I am drinking a cup of #coffee this cool #October. #awesome",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "October"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool <a href='https://jamesg.blog/tag/October'>#October</a>. #awesome",  # noqa: E501
+        ),
+        (
+            "I am having lunch with @james.",
+            "",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            [],
+            "I am having lunch with <a href='https://jamesg.blog'>James' Coffee Blog</a>.",
+        ),
+        (
+            "I am having #lunch with @james.",
+            "https://jamesg.blog/tag/",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            ["lunch", "dinner"],
+            "I am having <a href='https://jamesg.blog/tag/lunch'>#lunch</a> with <a href='https://jamesg.blog'>James' Coffee Blog</a>.",  # noqa: E501
+        ),
+        (
+            "I am having #lunch with @james. #indieweb",
+            "https://jamesg.blog/tag/",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            ["lunch", "indieweb"],
+            "I am having <a href='https://jamesg.blog/tag/lunch'>#lunch</a> with <a href='https://jamesg.blog'>James' Coffee Blog</a>. <a href='https://jamesg.blog/tag/indieweb'>#indieweb</a>",  # noqa: E501
+        ),
+    ],
+)
+def test_canonicalize_url(text, tag_prefix, people, tags, expected):
+    assert autolink_tags(text=text, tag_prefix=tag_prefix, people=people, tags=tags) == expected


### PR DESCRIPTION
This PR introduces new functions for use in TicketAuth redemption:

1. `send_ticket()` - Discover a ticket endpoint and send a ticket for a specified resource to the server.
2. `redeem_ticket()` - Makes a ticket redemption request to the token endpoint associated with a resource.

Documentation for the above functions are provided. The documentation notes these functions are experimental since TicketAuth is still in development.

There are not yet any test cases for these functions. I would like to work with someone to define what these should be.