### PR TITLE
Add `autolink_tags` function

### DIFF
--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -154,3 +154,4 @@ To check whether there is a two-way rel=me link between two resources, you can u
 This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
 rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
 if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user, even if the `get_valid_relmeauth_links()` function found a valid two-way rel=me link.
+

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -91,38 +91,8 @@ If a h-feed is found on the related document, the h-feed is returned.
 
 This function returns a dictionary with the h-card found on a web page.
 
-Add hashtags and person tags to a string
------------------------------------------
-
-The `autolink_tag()` function replaces hashtags (#) with links to tag pages on a specified site. It also replaces person tags (ex. @james) with provided names and links to the person's profile.
-
-This function is useful for enriching posts.
-
-To use this function, pass in the following arguments:
-
-.. autofunction:: indieweb_utils.autolink_tag
-
-This function will only substitute tags in the list of tags passed through to this function if a `tags` value is provided. This ensures that the function does not create links that your application cannot resolve.
-
-If you do not provide a `tags` value, the function will create links for all hashtags, as it is assumed that your application can resolve all hashtags.
-
-`Tagging people <https://indieweb.org/person-tag>`_ is enabled by providing a dictionary with information on all of the people to whom you can tag.
-
-If a person in an @ link is not in the tag dictionary, this function will not substitute that given @ link.
-
-Here is an example value for a person tag database:
-
-.. code-block:: python
-
-    {
-        "james": (
-            "James' Coffee Blog",
-            "https://jamesg.blog/""
-        )
-    }
-
-This function maps the `@james` tag with the name "James' Coffee Blog" and the URL "https://jamesg.blog/". More people can be added as keys to the dictionary.
-
+Generate reply context
+----------------------
 
 To generate reply context for a given page, use the following function:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -123,3 +123,88 @@ Here is an example value for a person tag database:
 
 This function maps the `@james` tag with the name "James' Coffee Blog" and the URL "https://jamesg.blog/". More people can be added as keys to the dictionary.
 
+
+To generate reply context for a given page, use the following function:
+
+.. autofunction:: indieweb_utils.get_reply_context
+
+This function returns a ReplyContext object that looks like this:
+
+.. autoclass:: indieweb_utils.ReplyContext
+
+Find the Original Version of a Post
+------------------------------------
+
+To find the original version of a post per the Original Post Discovery algorithm, use this code:
+
+.. autofunction:: indieweb_utils.discover_original_post
+
+This function returns the URL of the original version of a post, if one is found. Otherwise, None is returned.
+
+Send a Webmention
+------------------
+
+To send a webmention to a target, use this function:
+
+.. autofunction:: indieweb_utils.send_webmention
+
+This function returns a SendWebmentionResponse object with this structure:
+
+.. autoclass:: indieweb_utils.SendWebmentionResponse
+
+Discover all Feeds on a Page
+-----------------------------
+
+To discover the feeds on a page, use this function:
+
+.. autofunction:: indieweb_utils.discover_web_page_feeds
+
+This function returns a list with all feeds on a page.
+
+Each feed is structured as a FeedUrl object. FeedUrl objects contain the following attributes:
+
+.. autoclass:: indieweb_utils.FeedUrl
+
+Get a Representative h-card
+---------------------------
+
+To find the h-card that is considered representative of a web resource per the
+`Representative h-card Parsing Algorithm <https://microformats.org/wiki/representative-h-card-parsing>`_,
+use the following function:
+
+.. autofunction:: indieweb_utils.get_representative_h_card
+
+This function returns a dictionary with the h-card found on a web page.
+
+Add hashtags and person tags to a string
+-----------------------------------------
+
+The `autolink_tag()` function replaces hashtags (#) with links to tag pages on a specified site. It also replaces person tags (ex. @james) with provided names and links to the person's profile.
+
+This function is useful for enriching posts.
+
+To use this function, pass in the following arguments:
+
+.. autofunction:: indieweb_utils.autolink_tag
+
+This function will only substitute tags in the list of tags passed through to this function if a `tags` value is provided. This ensures that the function does not create links that your application cannot resolve.
+
+If you do not provide a `tags` value, the function will create links for all hashtags, as it is assumed that your application can resolve all hashtags.
+
+`Tagging people <https://indieweb.org/person-tag>`_ is enabled by providing a dictionary with information on all of the people to whom you can tag.
+
+If a person in an @ link is not in the tag dictionary, this function will not substitute that given @ link.
+
+Here is an example value for a person tag database:
+
+.. code-block:: python
+
+    {
+        "james": (
+            "James' Coffee Blog",
+            "https://jamesg.blog/""
+        )
+    }
+
+This function maps the `@james` tag with the name "James' Coffee Blog" and the URL "https://jamesg.blog/". More people can be added as keys to the dictionary.
+

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -88,3 +88,38 @@ The `discover_page_feed()` function implements the proposed `microformats2 h-fee
 This function looks for a h-feed on a given page. If one is not found, the function looks for a rel tag to a h-feed. If one is found, that document is parsed.
 
 If a h-feed is found on the related document, the h-feed is returned.
+
+This function returns a dictionary with the h-card found on a web page.
+
+Add hashtags and person tags to a string
+-----------------------------------------
+
+The `autolink_tag()` function replaces hashtags (#) with links to tag pages on a specified site. It also replaces person tags (ex. @james) with provided names and links to the person's profile.
+
+This function is useful for enriching posts.
+
+To use this function, pass in the following arguments:
+
+.. autofunction:: indieweb_utils.autolink_tag
+
+This function will only substitute tags in the list of tags passed through to this function if a `tags` value is provided. This ensures that the function does not create links that your application cannot resolve.
+
+If you do not provide a `tags` value, the function will create links for all hashtags, as it is assumed that your application can resolve all hashtags.
+
+`Tagging people <https://indieweb.org/person-tag>`_ is enabled by providing a dictionary with information on all of the people to whom you can tag.
+
+If a person in an @ link is not in the tag dictionary, this function will not substitute that given @ link.
+
+Here is an example value for a person tag database:
+
+.. code-block:: python
+
+    {
+        "james": (
+            "James' Coffee Blog",
+            "https://jamesg.blog/""
+        )
+    }
+
+This function maps the `@james` tag with the name "James' Coffee Blog" and the URL "https://jamesg.blog/". More people can be added as keys to the dictionary.
+

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -15,7 +15,7 @@ from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handl
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context
-from .utils.urls import canonicalize_url
+from .utils import autolink_tags, canonicalize_url
 from .webmentions import (
     SendWebmentionResponse,
     discover_webmention_endpoint,
@@ -49,4 +49,5 @@ __all__ = [
     "redeem_code",
     "get_valid_relmeauth_links",
     "validate_authorization_response",
+    "autolink_tags",
 ]

--- a/src/indieweb_utils/utils/__init__.py
+++ b/src/indieweb_utils/utils/__init__.py
@@ -1,3 +1,4 @@
+from .autotag import autolink_tags
 from .urls import _is_http_url, canonicalize_url
 
-__all__ = ["canonicalize_url", "_is_http_url"]
+__all__ = ["canonicalize_url", "_is_http_url", "autolink_tags"]

--- a/src/indieweb_utils/utils/autotag.py
+++ b/src/indieweb_utils/utils/autotag.py
@@ -1,8 +1,8 @@
 import re
-from typing import Set
+from typing import List
 
 
-def _match_tag(tag_prefix: str, match: str, user_tags: Set[str]) -> str:
+def _match_tag(tag_prefix: str, match: str, user_tags: List[str]) -> str:
     """
     Match a tag and return a link to the tag page.
 
@@ -10,8 +10,8 @@ def _match_tag(tag_prefix: str, match: str, user_tags: Set[str]) -> str:
     :type tag_prefix: str
     :param match: The match to process.
     :type match: str
-    :param user_tags: A set of tags that a user supports on their website.
-    :type user_tags: set
+    :param user_tags: A list of tags that a user supports on their website.
+    :type user_tags: List[str]
     :return: The processed match.
     :rtype: str
     """
@@ -40,7 +40,7 @@ def _match_person_tag(people: dict, match: str) -> str:
         return match
 
 
-def autolink_tags(text: str, tag_prefix: str, people: dict, tags: Set[str] = set()) -> str:
+def autolink_tags(text: str, tag_prefix: str, people: dict, tags: List[str] = None) -> str:
     """
     Replace hashtags (#) and person tags (@) with links to the respective tag page and profile URL.
 
@@ -50,8 +50,8 @@ def autolink_tags(text: str, tag_prefix: str, people: dict, tags: Set[str] = set
     :type tag_prefix: str
     :param people: A dictionary of people to link to.
     :type people: dict
-    :param tags: A set of tags to link to (optional).
-    :type tags: Set[str]
+    :param tags: A list of tags to link to (optional).
+    :type tags: List[str]
     :return: The processed text.
     :rtype: str
 
@@ -70,6 +70,11 @@ def autolink_tags(text: str, tag_prefix: str, people: dict, tags: Set[str] = set
         note_with_tags = indieweb_utils.autolink_tags(note, "/tag/", people, tags=["muffin", "recipe"])
 
     """
+
+    if tags is None:
+        tags = []
+        
+    tags = set(tags)
 
     text = re.sub(r"#(\w+)", lambda match: _match_tag(tag_prefix, match.group(), tags), text)
     text = re.sub(r"@(\w+)", lambda match: _match_person_tag(people, match.group()), text)

--- a/src/indieweb_utils/utils/autotag.py
+++ b/src/indieweb_utils/utils/autotag.py
@@ -1,0 +1,77 @@
+import re
+from typing import Set
+
+
+def _match_tag(tag_prefix: str, match: str, user_tags: Set[str]) -> str:
+    """
+    Match a tag and return a link to the tag page.
+
+    :param tag_prefix: The prefix to append to the tag.
+    :type tag_prefix: str
+    :param match: The match to process.
+    :type match: str
+    :param user_tags: A set of tags that a user supports on their website.
+    :type user_tags: set
+    :return: The processed match.
+    :rtype: str
+    """
+    tag = match[1:]
+    if len(user_tags) > 0 and tag in user_tags:
+        return f"<a href='{tag_prefix}{tag}'>#{tag}</a>"
+    else:
+        return match
+
+
+def _match_person_tag(people: dict, match: str) -> str:
+    """
+    A person tag and return a link to their profile.
+
+    :param people: A dictionary of names to which a person tag can be matched.
+    :type people: dict
+    :param match: The match to process.
+    :type match: str
+    :return: The processed match.
+    :rtype: str
+    """
+    person = match[1:]
+    if people.get(person):
+        return f"<a href='{people[person][1]}'>{people[person][0]}</a>"
+    else:
+        return match
+
+
+def autolink_tags(text: str, tag_prefix: str, people: dict, tags: Set[str] = set()) -> str:
+    """
+    Replace hashtags (#) and person tags (@) with links to the respective tag page and profile URL.
+
+    :param text: The text to process.
+    :type text: str
+    :param tag_prefix: The prefic to append to identified tags.
+    :type tag_prefix: str
+    :param people: A dictionary of people to link to.
+    :type people: dict
+    :param tags: A set of tags to link to (optional).
+    :type tags: Set[str]
+    :return: The processed text.
+    :rtype: str
+
+    Example:
+
+    ..code-block:: python
+
+        import indieweb_utils
+
+        note = "I am working on a new #muffin #recipe with @jane"
+
+        people = {
+            "jane": ("Jane Doe", "https://jane.example.com") # tag to use, name of person, domain of person
+        }
+
+        note_with_tags = indieweb_utils.autolink_tags(note, "/tag/", people, tags=["muffin", "recipe"])
+
+    """
+
+    text = re.sub(r"#(\w+)", lambda match: _match_tag(tag_prefix, match.group(), tags), text)
+    text = re.sub(r"@(\w+)", lambda match: _match_person_tag(people, match.group()), text)
+
+    return text

--- a/tests/test_utils/test_autotag.py
+++ b/tests/test_utils/test_autotag.py
@@ -1,0 +1,54 @@
+import pytest
+
+from indieweb_utils.utils import autolink_tags
+
+
+@pytest.mark.parametrize(
+    "text, tag_prefix, people, tags, expected",
+    [
+        (
+            "I am drinking a cup of #coffee this cool #October.",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "October"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool <a href='https://jamesg.blog/tag/October'>#October</a>.",  # noqa: E501
+        ),
+        (
+            "I am drinking a cup of #coffee this cool #October. #awesome",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "october"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool #October. #awesome",
+        ),
+        (
+            "I am drinking a cup of #coffee this cool #October. #awesome",
+            "https://jamesg.blog/tag/",
+            {},
+            ["coffee", "October"],
+            "I am drinking a cup of <a href='https://jamesg.blog/tag/coffee'>#coffee</a> this cool <a href='https://jamesg.blog/tag/October'>#October</a>. #awesome",  # noqa: E501
+        ),
+        (
+            "I am having lunch with @james.",
+            "",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            [],
+            "I am having lunch with <a href='https://jamesg.blog'>James' Coffee Blog</a>.",
+        ),
+        (
+            "I am having #lunch with @james.",
+            "https://jamesg.blog/tag/",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            ["lunch", "dinner"],
+            "I am having <a href='https://jamesg.blog/tag/lunch'>#lunch</a> with <a href='https://jamesg.blog'>James' Coffee Blog</a>.",  # noqa: E501
+        ),
+        (
+            "I am having #lunch with @james. #indieweb",
+            "https://jamesg.blog/tag/",
+            {"james": ("James' Coffee Blog", "https://jamesg.blog")},
+            ["lunch", "indieweb"],
+            "I am having <a href='https://jamesg.blog/tag/lunch'>#lunch</a> with <a href='https://jamesg.blog'>James' Coffee Blog</a>. <a href='https://jamesg.blog/tag/indieweb'>#indieweb</a>",  # noqa: E501
+        ),
+    ],
+)
+def test_canonicalize_url(text, tag_prefix, people, tags, expected):
+    assert autolink_tags(text=text, tag_prefix=tag_prefix, people=people, tags=tags) == expected


### PR DESCRIPTION
This PR creates a new `autolink_tags` function, with a test suite included.

This function accepts a list of tags and a dictionary with information about people to whom you may tag on your site. It then replaces # and @ tags in a string with links to your tag pages and the people to whom you are referring.

This function may be useful when writing an IndieWeb notes application, a social reader, or a public posting interface where you want to transform # and @ strings into links.