### PR TITLE
Fix response bug with IndieAuth callback handler

### DIFF
--- a/src/indieweb_utils/indieauth/flask.py
+++ b/src/indieweb_utils/indieauth/flask.py
@@ -19,13 +19,18 @@ def _validate_indieauth_response(me: str, response: requests.Response, required_
         message = "An invalid me value was provided."
         raise AuthenticationError(message)
 
-    if response.json().get("me").strip("/") != me.strip("/"):
+    response = response.json()
+
+    if response.get("me") is None:
+        raise AuthenticationError("There was an error with the IndieAuth server.")
+
+    if response.get("me").strip("/") != me.strip("/"):
         message = "Your domain is not allowed to access this website."
         raise AuthenticationError(message)
 
-    granted_scopes = response.json().get("scope").split(" ")
+    granted_scopes = response.get("scope").split(" ")
 
-    if response.json().get("scope") == "" or any(scope not in granted_scopes for scope in required_scopes):
+    if response.get("scope") is None or any(scope not in granted_scopes for scope in required_scopes):
         message = f"You need to grant {', '.join(required_scopes).strip(', ')} access to use this tool."
         raise AuthenticationError(message)
 
@@ -124,7 +129,7 @@ def indieauth_callback_handler(
 
     _validate_indieauth_response(me, auth_request, required_scopes)
 
-    return IndieAuthCallbackResponse(message="Authentication was successful.", response={})
+    return IndieAuthCallbackResponse(message="Authentication was successful.", response=auth_request.json())
 
 
 def is_authenticated(token_endpoint: str, headers: dict, session: dict, approved_user: bool = None) -> bool:


### PR DESCRIPTION
The `indieauth_callback_handler` function was not able to correctly process the JSON response from an authentication endpoint. Also, if a request was successful, a blank dictionary was returned instead of the response from the endpoint. This was not the intended behaviour.

This PR ensures the `_validate_indieauth_response` function, on which the aforementioned function depends, correctly processes the response from an endpoint. It also returns said response in the `indieauth_callback_handler` "response" value.