### PR TITLE
Support private webmentions

### DIFF
--- a/src/indieweb_utils/webmentions/send.py
+++ b/src/indieweb_utils/webmentions/send.py
@@ -65,7 +65,9 @@ def _validate_webmention(source: str, target: str):
         raise UnsupportedProtocolError("Only HTTP/HTTPS URLs are supported.")
 
 
-def send_webmention(source: str, target: str, me: str = None, code: str = None, realm: str = None) -> SendWebmentionResponse:
+def send_webmention(
+    source: str, target: str, me: str = None, code: str = None, realm: str = None
+) -> SendWebmentionResponse:
     """
     Send a webmention to a target URL.
 

--- a/src/indieweb_utils/webmentions/validate.py
+++ b/src/indieweb_utils/webmentions/validate.py
@@ -185,6 +185,10 @@ def validate_webmention(
     """
     Check if a webmention is valid.
 
+    :refs: https://indieweb.org/Webmention
+    :refs: https://indieweb.org/Private-Webmention
+    :refs: https://indieweb.org/Vouch
+
     :param source: The source URL of the webmention.
     :type source: str
     :param target: The target URL of the webmention.


### PR DESCRIPTION
This PR introduces the following changes:

1. `send_webmention` now supports optional `code` and `realm` values which can be passed on when sending a webmention.
2. `validate_webmention` accepts a `code` value for use in validating a private webmention. If the code value is provided, the new `_validate_private_webmention` helper function is invoked to redeem an access token to retrieve the webmention. If this function is successful, the access token will be passed in a WWW-Authenticate header to retrieve the source resource.