### PR TITLE
Add Flask indieauth functions to library

### DIFF
--- a/docs/source/indieauth.rst
+++ b/docs/source/indieauth.rst
@@ -215,3 +215,34 @@ An example endpoint response looks like this:
 This function does not check whether a URL has an OAuth provider. Your application should check the list of valid
 rel me links and only use those that integrate with the OAuth providers your RelMeAuth service supports. For example,
 if your service does not support Twitter, you should not present Twitter as a valid authentication option to a user, even if the `get_valid_relmeauth_links()` function found a valid two-way rel=me link.
+
+IndieAuth Login Scaffolding (Flask)
+-----------------------------------
+
+The `indieweb_utils.indieauth.decorators` module contains functions useful for building authentication systems with Flask.
+
+These functions are Flask-specific.
+
+Initiate an authentication request
+----------------------------------
+
+The `discover_auth_endpoint_decorator` function is meant to be used as a response to an endpoint on your site that discovers the IndieAuth endpoint for a given URL.
+
+This function discovers the IndieAuth endpoint for a resource then redirects a user to their IndieAuth endpoint to verify their identity.
+
+.. autofunction:: indieweb_utils.discover_auth_endpoint_decorator
+
+Handle an IndieAuth callback request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `indieauth_callback_response()` function should be used as a response to a callback endpoint on your site. This endpoint should be equal to the `callback_url` specified in the `discover_auth_endpoint_decorator` function.
+
+.. autofunction:: indieweb_utils.indieauth_callback_response
+
+This function will:
+
+1. Call the low-level `indieauth_callback_handler` function to verify the callback response.
+2. Set three values in your Flask session: `me`, `access_token`, and `scope`.
+3. Redirect you to the `redirect_success_destination` argument provided in the function.
+
+If there is an error, a user will be redirected to the value of the `redirect_error_destination` argument.

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -20,6 +20,10 @@ from .indieauth.flask_functions import (
     IndieAuthCallbackResponse,
     indieauth_callback_handler,
 )
+from .indieauth.decorators import (
+    indieauth_callback_response,
+    discover_auth_endpoint_decorator
+)
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context
@@ -70,4 +74,6 @@ __all__ = [
     "InvalidURL",
     "discover_endpoints",
     "_discover_endpoints",
+    "indieauth_callback_response",
+    "discover_auth_endpoint_decorator"
 ]

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -16,7 +16,10 @@ from .indieauth import (
     validate_access_token,
     validate_authorization_response,
 )
-from .indieauth.flask_functions import IndieAuthCallbackResponse, indieauth_callback_handler
+from .indieauth.flask_functions import (
+    IndieAuthCallbackResponse,
+    indieauth_callback_handler,
+)
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context

--- a/src/indieweb_utils/__init__.py
+++ b/src/indieweb_utils/__init__.py
@@ -16,7 +16,7 @@ from .indieauth import (
     validate_access_token,
     validate_authorization_response,
 )
-from .indieauth.flask import IndieAuthCallbackResponse, indieauth_callback_handler
+from .indieauth.flask_functions import IndieAuthCallbackResponse, indieauth_callback_handler
 from .posts.discovery import discover_author, discover_original_post, get_post_type
 from .posts.representative_h_card import get_representative_h_card
 from .replies import ReplyContext, get_reply_context

--- a/src/indieweb_utils/indieauth/__init__.py
+++ b/src/indieweb_utils/indieauth/__init__.py
@@ -1,4 +1,4 @@
-from .flask import (
+from .flask_functions import (
     _validate_indieauth_response,
     indieauth_callback_handler,
     is_authenticated,

--- a/src/indieweb_utils/indieauth/decorators.py
+++ b/src/indieweb_utils/indieauth/decorators.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import random
 import string
-from functools import wraps
 
 from flask import Flask, flash, redirect, request, session
 from flask_functions import AuthenticationError, indieauth_callback_handler

--- a/src/indieweb_utils/indieauth/decorators.py
+++ b/src/indieweb_utils/indieauth/decorators.py
@@ -3,15 +3,15 @@ import hashlib
 import random
 import string
 
-from flask import Flask, flash, redirect, request, session
-from flask_functions import AuthenticationError, indieauth_callback_handler
+from flask import Flask, flash, redirect, request, session, Response
+from .flask_functions import AuthenticationError, indieauth_callback_handler
 
 from ..webmentions.discovery import discover_endpoints
 
 
 def discover_auth_endpoint_decorator(
     client_id: str, callback_url: str, required_scopes: list, domain: str, redirect_failed_destination: str
-) -> Flask.Response:
+) -> Response:
     headers_to_find = ["authorization_endpoint", "token_endpoint"]
 
     headers = discover_endpoints(domain, headers_to_find)
@@ -66,7 +66,7 @@ def indieauth_callback_response(
     required_scopes: list,
     redirect_success_destination: str,
     redirect_failed_destination: str,
-) -> Flask.Response:
+) -> Response:
     code = request.args.get("code")
     state = request.args.get("state")
 

--- a/src/indieweb_utils/indieauth/decorators.py
+++ b/src/indieweb_utils/indieauth/decorators.py
@@ -1,0 +1,108 @@
+import base64
+import hashlib
+import random
+import string
+from functools import wraps
+
+from flask import Flask, flash, redirect, request, session
+from flask_functions import AuthenticationError, indieauth_callback_handler
+
+from ..webmentions.discovery import discover_endpoints
+
+
+def indieauth_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not session.get("me"):
+            flash("You must be logged in to access this page.")
+            return redirect("/login")
+
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
+def discover_auth_endpoint_decorator(
+    client_id: str, callback_url: str, required_scopes: list, domain: str, redirect_failed_destination: str
+) -> Flask.Response:
+    headers_to_find = ["authorization_endpoint", "token_endpoint"]
+
+    headers = discover_endpoints(domain, headers_to_find)
+
+    if not headers.get("authorization_endpoint"):
+        flash("A valid IndieAuth authorization endpoint could not be found on your website.")
+        return redirect(redirect_failed_destination)
+
+    if not headers.get("token_endpoint"):
+        flash("A valid IndieAuth token endpoint could not be found on your website.")
+        return redirect(redirect_failed_destination)
+
+    authorization_endpoint = headers.get("authorization_endpoint")
+    token_endpoint = headers.get("token_endpoint")
+
+    session["server_url"] = headers.get("microsub")
+
+    random_code = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30))
+
+    session["code_verifier"] = random_code
+    session["authorization_endpoint"] = authorization_endpoint
+    session["token_endpoint"] = token_endpoint
+
+    sha256_code = hashlib.sha256(random_code.encode("utf-8")).hexdigest()
+
+    code_challenge = base64.b64encode(sha256_code.encode("utf-8")).decode("utf-8")
+
+    state = "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+
+    session["state"] = state
+
+    return redirect(
+        authorization_endpoint
+        + "?client_id="
+        + client_id
+        + "&redirect_uri="
+        + callback_url
+        + "&scope=profile&response_type=code&code_challenge="
+        + code_challenge
+        + "&code_challenge_method=S256&state="
+        + state
+        + "&scope={}".format(" ".join(required_scopes))
+        + "&me="
+        + domain
+    )
+
+
+def indieauth_callback_response(
+    callback_url: str,
+    client_id: str,
+    me: str,
+    required_scopes: list,
+    redirect_success_destination: str,
+    redirect_failed_destination: str,
+) -> Flask.Response:
+    code = request.args.get("code")
+    state = request.args.get("state")
+
+    try:
+        response = indieauth_callback_handler(
+            code=code,
+            state=state,
+            token_endpoint=session.get("token_endpoint"),
+            code_verifier=session["code_verifier"],
+            session_state=session.get("state"),
+            callback_url=callback_url,
+            client_id=client_id,
+            me=me,
+            required_scopes=required_scopes,
+        )
+    except AuthenticationError:
+        flash("There was an error during authentication.")
+        return redirect(redirect_failed_destination)
+
+    session.pop("code_verifier")
+
+    session["me"] = response.response.get("me")
+    session["access_token"] = response.response.get("access_token")
+    session["scope"] = response.response.get("scope")
+
+    return redirect(redirect_success_destination)

--- a/src/indieweb_utils/indieauth/decorators.py
+++ b/src/indieweb_utils/indieauth/decorators.py
@@ -10,18 +10,6 @@ from flask_functions import AuthenticationError, indieauth_callback_handler
 from ..webmentions.discovery import discover_endpoints
 
 
-def indieauth_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        if not session.get("me"):
-            flash("You must be logged in to access this page.")
-            return redirect("/login")
-
-        return f(*args, **kwargs)
-
-    return decorated_function
-
-
 def discover_auth_endpoint_decorator(
     client_id: str, callback_url: str, required_scopes: list, domain: str, redirect_failed_destination: str
 ) -> Flask.Response:

--- a/src/indieweb_utils/indieauth/flask_functions.py
+++ b/src/indieweb_utils/indieauth/flask_functions.py
@@ -1,0 +1,187 @@
+from dataclasses import dataclass
+from typing import List
+
+import requests
+
+
+@dataclass
+class IndieAuthCallbackResponse:
+    message: str
+    response: dict
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+def _validate_indieauth_response(me: str, response: requests.Response, required_scopes: List[str]) -> None:
+    if me is None:
+        message = "An invalid me value was provided."
+        raise AuthenticationError(message)
+
+    if response.json().get("me").strip("/") != me.strip("/"):
+        message = "Your domain is not allowed to access this website."
+        raise AuthenticationError(message)
+
+    granted_scopes = response.json().get("scope").split(" ")
+
+    if response.json().get("scope") == "" or any(scope not in granted_scopes for scope in required_scopes):
+        message = f"You need to grant {', '.join(required_scopes).strip(', ')} access to use this tool."
+        raise AuthenticationError(message)
+
+
+def indieauth_callback_handler(
+    *,
+    code: str,
+    state: str,
+    token_endpoint: str,
+    code_verifier: str,
+    session_state: str,
+    me: str,
+    callback_url: str,
+    client_id: str,
+    required_scopes: List[str],
+) -> IndieAuthCallbackResponse:
+    """
+    Exchange a callback 'code' for an authentication token.
+
+    :param code: The callback 'code' to exchange for an authentication token.
+    :type code: str
+    :param state: The state provided by the authentication server in the callback response.
+    :type state: str
+    :param token_endpoint: The token endpoint to use for exchanging the callback 'code' for an authentication token.
+    :type token_endpoint: str
+    :param code_verifier: The code verifier to use for exchanging the callback 'code' for an authentication token.
+    :type code_verifier: str
+    :param session_state: The state stored in session used to verify the callback state is valid.
+    :type session_state: str
+    :param me: The URL of the user's profile.
+    :type me: str
+    :param callback_url: The callback URL used in the original authentication request.
+    :type callback_url: str
+    :param client_id: The client ID used in the original authentication request.
+    :type client_id: str
+    :param required_scopes: The scopes required for the application to work.
+        This list should not include optional scopes.
+    :type required_scopes: list[str]
+    :return: A message indicating the result of the callback (success or failure) and the token endpoint response.
+        The endpoint response will be equal to None if the callback failed.
+    :rtype: tuple[str, dict]
+
+    Example:
+
+    .. code-block:: python
+
+        import indieweb_utils
+        from Flask import flask
+
+        app = Flask(__name__)
+
+        @app.route("/indieauth/callback")
+        def callback():
+            response = indieweb_utils.indieauth_callback_handler(
+                code=request.args.get("code"),
+                state=request.args.get("state"),
+                token_endpoint="https://tokens.indieauth.com/token",
+                code_verifier=session["code_verifier"],
+                session_state=session["state"],
+                me=session["me"],
+                callback_url=session["callback_url"],
+                client_id=session["client_id"],
+                required_scopes=["create", "update", "delete"],
+            )
+
+            return response.message
+
+    :raises AuthenticationError: The token endpoint could not be accessed or authentication failed.
+    """
+
+    if state != session_state:
+        message = "The provided state value did not match the session state. Please try again."
+        raise AuthenticationError(message)
+
+    data = {
+        "code": code,
+        "redirect_uri": callback_url,
+        "client_id": client_id,
+        "grant_type": "authorization_code",
+        "code_verifier": code_verifier,
+    }
+
+    headers = {"Accept": "application/json"}
+
+    try:
+        auth_request = requests.post(token_endpoint, data=data, headers=headers)
+    except requests.exceptions.RequestException:
+        message = "Your token endpoint server could not be accessed."
+        raise AuthenticationError(message)
+
+    if auth_request.status_code != 200:
+        message = "There was an error with your token endpoint server."
+        raise AuthenticationError(message)
+
+    # remove code verifier from session because the authentication flow has finished
+
+    _validate_indieauth_response(me, auth_request, required_scopes)
+
+    return IndieAuthCallbackResponse(message="Authentication was successful.", response={})
+
+
+def is_authenticated(token_endpoint: str, headers: dict, session: dict, approved_user: bool = None) -> bool:
+    """
+    Check if a user has provided a valid Authorization header or access token in session. Designed for use with Flask.
+
+    :param token_endpoint: The token endpoint of the user's IndieAuth server.
+    :param headers: The headers sent by a request.
+    :param session: The session object from a Flask application.
+    :param approved_user: The optional URL of the that is approved to use the API.
+    :return: True if the user is authenticated, False otherwise.
+    :rtype: bool
+
+    Example:
+
+    .. code-block:: python
+
+        import indieweb_utils
+        from Flask import flask, request
+
+        app = Flask(__name__)
+
+        @app.route("/")
+        def index():
+            user_is_authenticated = indieweb_utils.is_authenticated(
+                "https://tokens.indieauth.com/token",
+                request.headers,
+                session,
+                "https://example.com/",
+            )
+
+            if user_is_authenticated is False:
+                return "Not authenticated"
+
+            return "Authenticated"
+
+    :raises AuthenticationError: The token endpoint could not be accessed.
+    """
+    if headers.get("Authorization") is not None:
+        access_token = headers["Authorization"].split(" ")[-1]
+
+    elif session.get("access_token"):
+        access_token = session.get("access_token")
+    else:
+        return False
+
+    try:
+        check_token = requests.get(token_endpoint, headers={"Authorization": f"Bearer {access_token}"}, timeout=5)
+    except requests.exceptions.Timeout:
+        raise AuthenticationError("The specified token endpoint timed out.")
+    except requests.exceptions.RequestException:
+        raise AuthenticationError("The specified token endpoint could not be accessed.")
+
+    if check_token.status_code != 200 or not check_token.json().get("me"):
+        return False
+
+    if approved_user is not None and check_token.status_code != 200 and check_token.json()["me"] != approved_user:
+        return False
+
+    return True


### PR DESCRIPTION
This PR introduces two new functions intended for use when adding authentication to a Python Flask app:

1. `discover_auth_endpoint_decorator`: Intended to be used as a return value for an endpoint that discovers an IndieAuth endpoint and redirects a user to their endpoint for identity verification.
2. `indieauth_callback_response`: Abstracts the `indieauth_callback_handler` and sets `me`, `access_token`, and `scope` in the Flask `session` object for further use.

Documentation for these two functions is included in the PR.

This PR also renames the file called `flask.py` to `flask_functions.py` and updates import statements across the library as required. This is because there is a naming conflict between this file and the `flask` library.

_**Note**: We may need to add a statement in the root `__init__.py` file to maintain backwards compatibility._

I am curious about whether this should be in IndieWeb Utils or if this should be its own library.

I am also open to feedback on the names of these functions. They may be confusing since they are close to other IndieAuth-related functions in the library.