### PR TITLE
Improve reply context retrieval logic and fix bugs

### DIFF
--- a/tests/test_replies/test_context.py
+++ b/tests/test_replies/test_context.py
@@ -42,6 +42,7 @@ class TestReplyContext:
         assert reply_context.photo == ""
         assert reply_context.post_html
         assert reply_context.post_text
+        assert reply_context.description == "This post exists to collect my notes on displaying a USB webcam on the Raspberry Pi HDMI outputs. This is not the same as streaming the webcam (easy), and this is not for use with the Raspberry Pi camera module..."
 
     @responses.activate
     def test_reply_context_3(self):
@@ -64,6 +65,7 @@ class TestReplyContext:
         )
         assert reply_context.post_html
         assert reply_context.post_text
+        assert reply_context.description == "Good sound, noise cancelling and spatial audio, with six-hour battery, Android support and cheaper price"
 
     @responses.activate
     def test_reply_context_4(self):
@@ -81,3 +83,4 @@ class TestReplyContext:
         assert reply_context.photo == ""
         assert reply_context.post_html
         assert reply_context.post_text
+        assert reply_context.description == ""


### PR DESCRIPTION
This PR:

1. Adds functionality to search meta Twitter, OpenGraph, and description values to find a description for a page where a h-entry object cannot be found.
2. Checks Twitter, OpenGraph, and meta image values to find a photo that represents a page where a h-entry object cannot be found.
3. Runs the linter on our reply context file.
4. Fixes logic for reply context summaries where a blank summary would be returned for any article.
5. Updates reply context test cases to check for descriptions.