### PR TITLE
Change license to 0 BSD (source code) and CC BY-SA 4.0 (documentation)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,5 @@
-Copyright 2022 capjamesg
+Zero-Clause BSD
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,9 @@ The documentation for this project is available at `indieweb-utils.readthedocs.i
 License
 -------
 
-This project is licensed under the `MIT license <LICENSE>`_.
+The code in this project is licensed under the `Zero-Clause BSD License <LICENSE>`_.
+
+The documentation in this project is licensed under a `CC BY-SA 4.0 license <https://creativecommons.org/licenses/by-sa/4.0/>`_.
 
 Dependencies
 --------------


### PR DESCRIPTION
This PR changes the license of the IndieWeb Utils source code from MIT to 0 BSD. The license for documentation is changed to CC BY-SA 4.0 from MIT in this PR, too.

To make this change, consent is required from @jamesvandyne and @angelogladding. This consent will be measured as an approval from each requested reviewer on this PR or a comment left indicating one's support for the change.

This change is being proposed after discussion in issue #73.