### PR TITLE
Made requirements.txt and setup.py dependencies match

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ requests
 beautifulsoup4==4.10.0
 lxml
 pyjwt==2.4.0
-Pillow
+jwt==1.3.1
 granary
+Pillow

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "mf2py==1.1.2",
         "requests",
         "beautifulsoup4==4.10.0",
-        "lxml==4.9.1",
+        "lxml",
         "pyjwt==2.4.0",
         "jwt==1.3.1",
         "granary",


### PR DESCRIPTION
## Changes

`setup.py` was using a fixed version of `lxml` while `requirements.txt` didn't, and the fixed version of lxml wasn't working with the latest version of Python 3.12. As I saw that for working locally it was fine to use the latest lxml (and the tests pass), I figured that a good approach was to make both lists match. I also did test with Python 3.9 (using docker).

Tho perhaps the `requirements.txt` file could install the local files to avoid having to keep an eye on both lists by having one source of truth, with its content be something like:

    -e .